### PR TITLE
Frontend Dashboard Page

### DIFF
--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,0 +1,95 @@
+"use client";
+import React from "react";
+import DummyTable from "@/components/molecules/DummyTable";
+import DashboardTemplate from "@/components/templates/DashboardTemplate";
+
+const DashboardPage = () => {
+  return (
+    <DashboardTemplate>
+      <div className="mb-8 text-4xl font-bold">Museum of the Sea</div>
+      <div className="flex items-center justify-between">
+        <div className="text-3xl font-medium">Contribution Total</div>
+        <button className="mb-2 me-2 inline-flex items-center rounded-xl bg-gray-200 px-4 py-1.5 text-center text-lg font-light text-black hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-300">
+          Export
+          <svg
+            className="ml-2 h-5 w-5 text-black dark:text-white"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div className="mt-4 h-96 w-auto rounded-3xl bg-gray-100 p-6">
+        Overall Contributions Graph
+      </div>
+
+      <div className="mb-4 mt-12 flex items-center justify-between">
+        <div className="text-3xl font-medium">Recent Contributions</div>
+        <button className="mb-2 me-2 inline-flex items-center rounded-xl bg-gray-200 px-4 py-1.5 text-center text-lg font-light text-black hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-300">
+          Export
+          <svg
+            className="ml-2 h-5 w-5 text-black dark:text-white"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <DummyTable></DummyTable>
+
+      <div className="mt-12 flex items-center justify-between">
+        <div className="text-3xl font-medium">Activity Level</div>
+        <button className="mb-2 me-2 inline-flex items-center rounded-xl bg-gray-200 px-4 py-1.5 text-center text-lg font-light text-black hover:bg-gray-300 focus:outline-none focus:ring-2 focus:ring-gray-300 dark:border-gray-300">
+          Export
+          <svg
+            className="ml-2 h-5 w-5 text-black dark:text-white"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="24"
+            height="24"
+            fill="none"
+            viewBox="0 0 24 24"
+          >
+            <path
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <div className="mt-4 h-96 w-auto rounded-3xl bg-gray-100 p-6">
+        Contributions per month graph
+      </div>
+    </DashboardTemplate>
+  );
+};
+
+export default DashboardPage;


### PR DESCRIPTION
## Summary

<!-- Summarize your changes here. -->
We created a dashboard directory with a `page.tsx` file and imported the DashboardTemplate for the sidebar. Then, we developed the titles, export buttons, and dummy graphs and tables according to the Figma dashboard design. 

![localhost_3000_dashboard (1)](https://github.com/user-attachments/assets/7eb4b503-0d22-46bc-bae8-6d9a0b6c4c00)


## Testing

In order to access the dashboard page from the route, navigate to the `middleware.ts` file in the src folder and move "/dashboard" from adminPaths to publicPaths. One can now access the route /dashboard without having to login.
<img width="457" alt="Screenshot 2024-10-30 at 9 00 34 PM" src="https://github.com/user-attachments/assets/f13fbe19-2bd5-41b8-8edb-45144c7fed58">

## Notes

In future PRs, we plan to replace the dummy boxes with the contribution total graph and the activity level graph. For code readability, we could also make the export button a component that takes in data/actions in order to avoid the repetition of the export svg code. 

closes #38