### PR TITLE
Add transaction modal

### DIFF
--- a/frontend/src/app/test/modaltest/page.tsx
+++ b/frontend/src/app/test/modaltest/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Button from "@/components/atoms/Button";
+import TransactionModal from "@/components/molecules/AddTransactionModal";
 import {
   Dialog,
   DialogContent,
@@ -42,18 +43,23 @@ const Modal: React.FC<ModalProps> = ({
 const ExamplePage = () => {
   return (
     <div className="p-4">
-      <Modal
-        buttonText="Click me!"
-        title="Welcome"
-        description="This is a sample modal dialog"
-      >
-        <div className="space-y-4">
-          <p>This is the modal content.</p>
-          <p>You can put anything you want in here!</p>
-        </div>
-      </Modal>
+      <TransactionModal>
+        
+      </TransactionModal>
     </div>
   );
 };
 
 export default ExamplePage;
+
+
+{/* <Modal
+buttonText="Click me!"
+title="Welcome"
+description="This is a sample modal dialog"
+>
+<div className="space-y-4">
+  <p>This is the modal content.</p>
+  <p>You can put anything you want in here!</p>
+</div>
+</Modal> */}

--- a/frontend/src/app/test/modaltest/page.tsx
+++ b/frontend/src/app/test/modaltest/page.tsx
@@ -43,23 +43,9 @@ const Modal: React.FC<ModalProps> = ({
 const ExamplePage = () => {
   return (
     <div className="p-4">
-      <TransactionModal>
-        
-      </TransactionModal>
+      <TransactionModal></TransactionModal>
     </div>
   );
 };
 
 export default ExamplePage;
-
-
-{/* <Modal
-buttonText="Click me!"
-title="Welcome"
-description="This is a sample modal dialog"
->
-<div className="space-y-4">
-  <p>This is the modal content.</p>
-  <p>You can put anything you want in here!</p>
-</div>
-</Modal> */}

--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -31,7 +31,12 @@ export function DatePicker() {
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-auto p-0">
-        <Calendar mode="single" selected={date} onSelect={setDate} />
+        <Calendar
+          mode="single"
+          selected={date}
+          onSelect={setDate}
+          // initialFocus
+        />
       </PopoverContent>
     </Popover>
   );

--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -1,45 +1,38 @@
 "use client";
-import React from "react";
+
+import * as React from "react";
 import { format } from "date-fns";
-import { CalendarIcon } from "lucide-react";
-import { Calendar } from "@/components/ui/calendar";
+import { Calendar as CalendarIcon } from "lucide-react";
+
+import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
+import { Calendar } from "@/components/ui/calendar";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
 
-const DatePicker = ({
-  selectedDate,
-  onSelect,
-}: {
-  selectedDate: Date | undefined;
-  onSelect: (date: Date | undefined) => void;
-}) => {
+export function DatePicker() {
+  const [date, setDate] = React.useState<Date>();
+
   return (
     <Popover>
       <PopoverTrigger asChild>
         <Button
-          variant="outline"
-          className="h-[51px] w-[268px] pl-3 text-left font-normal"
+          variant={"outline"}
+          className={cn(
+            "w-[280px] justify-start text-left font-normal",
+            !date && "text-muted-foreground"
+          )}
         >
-          {selectedDate ? format(selectedDate, "PPP") : "Pick a date"}
-          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+          <CalendarIcon className="mr-2 h-4 w-4" />
+          {date ? format(date, "PPP") : <span>Pick a date</span>}
         </Button>
       </PopoverTrigger>
-      <PopoverContent className="w-auto p-0" align="start">
-        <Calendar
-          mode="single"
-          selected={selectedDate}
-          onSelect={onSelect}
-          disabled={(date) =>
-            date > new Date() || date < new Date("1900-01-01")
-          }
-        />
+      <PopoverContent className="w-auto p-0">
+        <Calendar mode="single" selected={date} onSelect={setDate} />
       </PopoverContent>
     </Popover>
   );
-};
-
-export default DatePicker;
+}

--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -1,0 +1,50 @@
+"use client"
+
+import { format } from "date-fns"
+import { CalendarIcon } from "lucide-react"
+import { useForm } from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { toast } from "@/components/hooks/use-toast"
+import { Button } from "@/components/ui/button"
+import { Calendar } from "@/components/ui/calendar"
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover"
+
+export function DatePicker() {
+  return (
+    
+              <Popover>
+                <PopoverTrigger asChild>
+                    <Button
+                      variant={"outline"}
+                      className={cn(
+                        "w-[240px] pl-3 text-left font-normal",
+                        !field.value && "text-muted-foreground"
+                      )}
+                    >
+                      {field.value ? (
+                        format(field.value, "PPP")
+                      ) : (
+                        <span>Pick a date</span>
+                      )}
+                      <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+                    </Button>
+                </PopoverTrigger>
+                <PopoverContent className="w-auto p-0" align="start">
+                  <Calendar
+                    mode="single"
+                    selected={field.value}
+                    onSelect={field.onChange}
+                    disabled={(date) =>
+                      date > new Date() || date < new Date("1900-01-01")
+                    }
+                    initialFocus
+                  />
+                </PopoverContent>
+              </Popover>
+  )
+}

--- a/frontend/src/components/atoms/DatePicker.tsx
+++ b/frontend/src/components/atoms/DatePicker.tsx
@@ -1,50 +1,45 @@
-"use client"
-
-import { format } from "date-fns"
-import { CalendarIcon } from "lucide-react"
-import { useForm } from "react-hook-form"
-
-import { cn } from "@/lib/utils"
-import { toast } from "@/components/hooks/use-toast"
-import { Button } from "@/components/ui/button"
-import { Calendar } from "@/components/ui/calendar"
+"use client";
+import React from "react";
+import { format } from "date-fns";
+import { CalendarIcon } from "lucide-react";
+import { Calendar } from "@/components/ui/calendar";
+import { Button } from "@/components/ui/button";
 import {
   Popover,
   PopoverContent,
   PopoverTrigger,
-} from "@/components/ui/popover"
+} from "@/components/ui/popover";
 
-export function DatePicker() {
+const DatePicker = ({
+  selectedDate,
+  onSelect,
+}: {
+  selectedDate: Date | undefined;
+  onSelect: (date: Date | undefined) => void;
+}) => {
   return (
-    
-              <Popover>
-                <PopoverTrigger asChild>
-                    <Button
-                      variant={"outline"}
-                      className={cn(
-                        "w-[240px] pl-3 text-left font-normal",
-                        !field.value && "text-muted-foreground"
-                      )}
-                    >
-                      {field.value ? (
-                        format(field.value, "PPP")
-                      ) : (
-                        <span>Pick a date</span>
-                      )}
-                      <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
-                    </Button>
-                </PopoverTrigger>
-                <PopoverContent className="w-auto p-0" align="start">
-                  <Calendar
-                    mode="single"
-                    selected={field.value}
-                    onSelect={field.onChange}
-                    disabled={(date) =>
-                      date > new Date() || date < new Date("1900-01-01")
-                    }
-                    initialFocus
-                  />
-                </PopoverContent>
-              </Popover>
-  )
-}
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="outline"
+          className="h-[51px] w-[268px] pl-3 text-left font-normal"
+        >
+          {selectedDate ? format(selectedDate, "PPP") : "Pick a date"}
+          <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-auto p-0" align="start">
+        <Calendar
+          mode="single"
+          selected={selectedDate}
+          onSelect={onSelect}
+          disabled={(date) =>
+            date > new Date() || date < new Date("1900-01-01")
+          }
+        />
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default DatePicker;

--- a/frontend/src/components/atoms/ScrollableSelect.tsx
+++ b/frontend/src/components/atoms/ScrollableSelect.tsx
@@ -1,0 +1,41 @@
+"use client";
+import * as React from "react";
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+interface ScrollSelectProps {
+  placeholder?: string;
+  values?: string[];
+  width?: string;
+}
+
+const ScrollableSelect = ({
+  placeholder,
+  values = [],
+  width,
+}: ScrollSelectProps) => {
+  return (
+    <Select>
+      <SelectTrigger className={width}>
+        <SelectValue placeholder={placeholder} />
+      </SelectTrigger>
+      <SelectContent>
+        {values.map((value, index) => (
+          <SelectItem key={`${value}-${index}`} value={`${value}-${index}`}>
+            {value}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};
+
+export default ScrollableSelect;

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -4,10 +4,17 @@ import Button from "@/components/atoms/Button";
 import Input from "@/components/atoms/Input";
 import Radio from "@/components/atoms/Radio";
 import Select from "@/components/atoms/Select";
+import ScrollableSelect from "@/components/atoms/ScrollableSelect";
 import { ScrollArea } from "@/components/ui/scroll";
-import { DatePicker } from "@/components/atoms/DatePicker";
+// import { DatePicker } from "@/components/atoms/DatePicker";
 import { Calendar } from "@/components/ui/calendar";
 import DragDrop from "@/components/molecules/DragDrop";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radiogroup";
+import { ShadInput } from "@/components/ui/input";
+
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 
 import {
   Dialog,
@@ -25,7 +32,7 @@ const TransactionModal = ({}) => {
       <DialogTrigger asChild>
         <Button>Add Transaction</Button>
       </DialogTrigger>
-      <DialogContent className="h-[800px] w-[810px] justify-center rounded-[40px] px-[100px] pt-[100px]">
+      <DialogContent className="h-[800px] w-[810px] justify-center rounded-[40px] px-[100px] pt-[100px] [&>button]:hidden">
         <ScrollArea className="h-full w-[600px]">
           <DialogHeader>
             <DialogTitle className="mb-[48px] text-[32px]">
@@ -34,44 +41,80 @@ const TransactionModal = ({}) => {
           </DialogHeader>
           <div className="mb-2 text-[22px]">Date</div>
           <div>
-            <DatePicker></DatePicker>
+            <LocalizationProvider dateAdapter={AdapterDayjs}>
+              <DatePicker />
+            </LocalizationProvider>
+            {/* <DatePicker></DatePicker> */}
           </div>
-          <div className="mt-[32px] text-[22px]">Contributer</div>
-          <Select
+          <div className="mb-2 mt-[32px] text-[22px]">Contributer</div>
+          <ScrollableSelect
             placeholder="Select a Contributer"
-            values={["Sarah Clay", "Theo Rumberg", "Brandon Wu"]}
-            width="95%"
-          ></Select>
-          <div className="mt-[32px] text-[22px]">Fund</div>
-          <Select
+            values={[
+              "Sarah Clay",
+              "Theo Rumberg",
+              "Brandon Wu",
+              "Sarah Clay",
+              "Theo Rumberg",
+              "Brandon Wu",
+              "Sarah Clay",
+              "Theo Rumberg",
+              "Brandon Wu",
+              "Sarah Clay",
+              "Theo Rumberg",
+              "Brandon Wu",
+              "Sarah Clay",
+              "Theo Rumberg",
+              "Brandon Wu",
+            ]}
+            width="w-[580px]"
+          ></ScrollableSelect>
+          <div className="mb-2 mt-[32px] text-[22px]">Fund</div>
+          <ScrollableSelect
             placeholder="Select a Fund"
             values={["Robert Fund", "Sophie Fund", "Edward Fund"]}
-            width="95%"
-          ></Select>
+            width="w-[580px]"
+          ></ScrollableSelect>
           <div className="mb-2 mt-[32px] text-[22px]">Amount</div>
           <Input
-            id="amount"
-            defaultValue="$"
-            className="mr-4 block w-[95%] rounded-lg border border-black px-2 py-3.5 text-sm text-gray-900 placeholder-gray-500 hover:bg-gray-100"
+            type="text"
+            placeholder="Enter an Amount"
+            className="flex h-9 w-[95%] rounded-md border border-black bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:border-black focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50"
           />
           <div className="mb-2 mt-[32px] text-[22px]">Units purchased</div>
           <Input
-            id="units purchased"
-            className="mr-4 block w-[95%] rounded-lg border border-gray-900 bg-gray-200 px-2 py-3.5 text-sm text-gray-900 placeholder-gray-500 hover:bg-gray-100"
+            type="text"
+            placeholder=""
+            className="flex h-9 w-[95%] rounded-md border border-black bg-gray-100 px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus:border-black focus:ring-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
           />
           <div className="mt-[32px] grid grid-cols-2">
             <div className="justify-start">
               <div className="text-[22px]">Transaction</div>
-              <div className="ml-2 mt-3 space-y-2 text-[22px]">
-                <Radio label="Deposit"></Radio>
-                <Radio label="Withdrawl"></Radio>
+              <div className="ml-2 mt-4 space-y-2 text-[22px]">
+                <RadioGroup defaultValue="comfortable">
+                  <div className="flex items-center space-x-4">
+                    <RadioGroupItem value="default" id="r1" />
+                    <div className="text-[18px]">Deposit</div>
+                  </div>
+                  <div className="flex items-center space-x-4">
+                    <RadioGroupItem value="compact" id="r2" />
+                    <div className="text-[18px]">Withdrawl</div>
+                  </div>
+                </RadioGroup>
               </div>
             </div>
             <div className="justify-start">
               <div className="text-[22px]">Type</div>
-              <div className="ml-2 mt-3 space-y-2 text-[22px]">
-                <Radio label="Donation"></Radio>
-                <Radio label="Endowment"></Radio>
+              <div className="ml-2 mt-4 space-y-2 text-[22px]">
+                <RadioGroup defaultValue="comfortable">
+                  <div className="flex items-center space-x-4">
+                    <RadioGroupItem value="default" id="r1" />
+                    <div className="text-[18px]">Donation</div>
+                  </div>
+                  <div className="flex items-center space-x-4">
+                    <RadioGroupItem value="compact" id="r2" />
+                    <div className="text-[18px]">Endowment</div>
+                  </div>
+                </RadioGroup>
               </div>
             </div>
           </div>
@@ -82,7 +125,7 @@ const TransactionModal = ({}) => {
             </div>
           </div>
           <textarea
-            className="ml-0.5 mt-[42px] h-[150px] w-[95%] rounded-2xl border border-black"
+            className="ml-0.5 mt-[42px] h-[150px] w-[95%] rounded-2xl border border-black focus:border-black focus:ring-0"
             placeholder="Add a description"
             rows={4}
             cols={40}
@@ -101,7 +144,7 @@ const TransactionModal = ({}) => {
             <Button className="absolute left-0 mb-2 me-2 rounded-2xl border border-black px-16 py-3 text-lg text-black hover:bg-grey-dark focus:outline-none">
               Cancel
             </Button>
-            <Button className="absolute right-5 mb-2 me-2 rounded-2xl border border-black bg-gray-800 px-20 py-3 text-lg text-white hover:bg-grey-dark focus:outline-none">
+            <Button className="absolute right-5 mb-2 me-2 rounded-2xl border bg-gray-600 px-20 py-3 text-lg text-white hover:bg-grey-dark focus:outline-none">
               Add
             </Button>
           </div>

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -7,6 +7,7 @@ import Select from "@/components/atoms/Select";
 import { ScrollArea } from "@/components/ui/scroll";
 import { DatePicker } from "@/components/atoms/DatePicker";
 import { Calendar } from "@/components/ui/calendar";
+import DragDrop from "@/components/molecules/DragDrop";
 
 import {
   Dialog,
@@ -38,13 +39,13 @@ const TransactionModal = ({}) => {
           <div className="mt-[32px] text-[22px]">Contributer</div>
           <Select
             placeholder="Select a Contributer"
-            values={["Robert Fund", "Sophie Fund", "Edward Fund"]}
+            values={["Sarah Clay", "Theo Rumberg", "Brandon Wu"]}
             width="95%"
           ></Select>
           <div className="mt-[32px] text-[22px]">Fund</div>
           <Select
             placeholder="Select a Fund"
-            values={["Sarah Clay", "Theo Rumberg", "Brandon Wu"]}
+            values={["Robert Fund", "Sophie Fund", "Edward Fund"]}
             width="95%"
           ></Select>
           <div className="mb-2 mt-[32px] text-[22px]">Amount</div>
@@ -96,12 +97,12 @@ const TransactionModal = ({}) => {
               Optional
             </div>
           </div>
-          <div className="mt-[46px] h-[51px] w-[95%] rounded-lg bg-gray-200"></div>
-          <div className="relative mt-[100px]">
-            <Button className="absolute left-0 mb-2 me-2 rounded-2xl border border-black px-16 py-3 text-lg text-black hover:bg-grey-dark focus:outline-none focus:ring-4 focus:ring-gray-300">
+          <DragDrop></DragDrop>
+          <div className="relative mb-2 mt-[100px]">
+            <Button className="absolute left-0 mb-2 me-2 rounded-2xl border border-black px-16 py-3 text-lg text-black hover:bg-grey-dark focus:outline-none">
               Cancel
             </Button>
-            <Button className="absolute right-5 mb-2 me-2 rounded-2xl border border-black bg-gray-800 px-20 py-3 text-lg text-white hover:bg-grey-dark focus:outline-none focus:ring-4 focus:ring-gray-300">
+            <Button className="absolute right-5 mb-2 me-2 rounded-2xl border border-black bg-gray-800 px-20 py-3 text-lg text-white hover:bg-grey-dark focus:outline-none">
               Add
             </Button>
           </div>

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -1,12 +1,12 @@
-import React from "react";
+"use client";
+import React, { useState } from "react";
 import Button from "@/components/atoms/Button";
 import Input from "@/components/atoms/Input";
 import Radio from "@/components/atoms/Radio";
 import Select from "@/components/atoms/Select";
 import { ScrollArea } from "@/components/ui/scroll";
-import { Separator } from "@/components/ui/separator";
+import DatePicker from "@/components/atoms/DatePicker";
 import { Calendar } from "@/components/ui/calendar";
-import { DatePicker } from "@/components/atoms/DatePicker";
 
 import {
   Dialog,
@@ -19,6 +19,8 @@ import {
 } from "@/components/ui/dialog";
 
 const TransactionModal = ({}) => {
+  const [date, setDate] = React.useState<Date | undefined>(new Date());
+
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -33,7 +35,12 @@ const TransactionModal = ({}) => {
           </DialogHeader>
           <div className="mb-2 text-[22px]">Date</div>
           <div className="h-[51px] w-[268px] rounded-lg bg-gray-200">
-            {/* <DatePicker/> */}
+            <Calendar
+              mode="single"
+              selected={date}
+              onSelect={setDate}
+              className="rounded-md border"
+            />
           </div>
           <div className="mt-[32px] text-[22px]">Contributer</div>
           <Select

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -1,0 +1,82 @@
+import React from "react";
+import Button from "@/components/atoms/Button";
+import Input from "@/components/atoms/Input";
+import Radio from "@/components/atoms/Radio";
+import { ScrollArea } from "@/components/ui/scroll"
+import { Separator } from "@/components/ui/separator"
+import { Calendar } from "@/components/ui/calendar";
+import { DatePicker } from "@/components/atoms/DatePicker";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+
+
+
+const TransactionModal = ({}) => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button >Add Transaction</Button>
+      </DialogTrigger>
+      <DialogContent className="pt-[100px] px-[100px] w-[810px] h-[800px] justify-center rounded-[40px]">
+      <ScrollArea className="w-full h-full">
+        <DialogHeader>
+          <DialogTitle className="text-[32px] mb-[48px]">Add Transaction</DialogTitle>
+        </DialogHeader>
+        <div className="text-[22px] mb-2">Date</div>
+        <div className="h-[51px] w-[268px] rounded-lg bg-gray-200">
+        {/* <DatePicker/> */}
+        </div>
+        <div className="text-[22px] mt-[32px]">Contributer</div>
+
+        <div className="text-[22px] mt-[32px]">Fund</div>
+
+        <div className="text-[22px] mt-[32px]">Amount</div>
+        <div className="grid grid-cols-4 ">
+        <Input
+                id="amount"
+                defaultValue="Pedro Duarte"
+                className="col-span-3"
+              />
+        </div>
+
+        <div className="text-[22px] mt-[32px]">Units purchased</div>
+        <Input
+                id="fund"
+                defaultValue="Pedro Duarte"
+                className="col-span-3"
+              />
+
+        <div className="grid grid-cols-2 mt-[32px]">
+            <div className="justify-start">
+                <div className="text-[22px]">Transaction</div>
+                <div className="ml-2"><Radio label="Deposit" ></Radio>
+                <Radio label="Withdrawl"></Radio></div>
+            </div>
+            <div className="justify-start">
+                <div className="text-[22px]">Type</div>
+                <div className="ml-2"><Radio label="Deposit"></Radio>
+                <Radio label="Withdrawl"></Radio></div>
+            </div>
+        </div>
+
+            
+        <DialogFooter>
+            <Button variant = "primary">
+              Add
+              </Button>
+          </DialogFooter>
+          </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default TransactionModal;

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -2,8 +2,9 @@ import React from "react";
 import Button from "@/components/atoms/Button";
 import Input from "@/components/atoms/Input";
 import Radio from "@/components/atoms/Radio";
-import { ScrollArea } from "@/components/ui/scroll"
-import { Separator } from "@/components/ui/separator"
+import Select from "@/components/atoms/Select";
+import { ScrollArea } from "@/components/ui/scroll";
+import { Separator } from "@/components/ui/separator";
 import { Calendar } from "@/components/ui/calendar";
 import { DatePicker } from "@/components/atoms/DatePicker";
 
@@ -17,63 +18,95 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 
-
-
 const TransactionModal = ({}) => {
   return (
     <Dialog>
       <DialogTrigger asChild>
-        <Button >Add Transaction</Button>
+        <Button>Add Transaction</Button>
       </DialogTrigger>
-      <DialogContent className="pt-[100px] px-[100px] w-[810px] h-[800px] justify-center rounded-[40px]">
-      <ScrollArea className="w-full h-full">
-        <DialogHeader>
-          <DialogTitle className="text-[32px] mb-[48px]">Add Transaction</DialogTitle>
-        </DialogHeader>
-        <div className="text-[22px] mb-2">Date</div>
-        <div className="h-[51px] w-[268px] rounded-lg bg-gray-200">
-        {/* <DatePicker/> */}
-        </div>
-        <div className="text-[22px] mt-[32px]">Contributer</div>
-
-        <div className="text-[22px] mt-[32px]">Fund</div>
-
-        <div className="text-[22px] mt-[32px]">Amount</div>
-        <div className="grid grid-cols-4 ">
-        <Input
-                id="amount"
-                defaultValue="Pedro Duarte"
-                className="col-span-3"
-              />
-        </div>
-
-        <div className="text-[22px] mt-[32px]">Units purchased</div>
-        <Input
-                id="fund"
-                defaultValue="Pedro Duarte"
-                className="col-span-3"
-              />
-
-        <div className="grid grid-cols-2 mt-[32px]">
+      <DialogContent className="h-[800px] w-[810px] justify-center rounded-[40px] px-[100px] pt-[100px]">
+        <ScrollArea className="h-full w-[600px]">
+          <DialogHeader>
+            <DialogTitle className="mb-[48px] text-[32px]">
+              Add Transaction
+            </DialogTitle>
+          </DialogHeader>
+          <div className="mb-2 text-[22px]">Date</div>
+          <div className="h-[51px] w-[268px] rounded-lg bg-gray-200">
+            {/* <DatePicker/> */}
+          </div>
+          <div className="mt-[32px] text-[22px]">Contributer</div>
+          <Select
+            placeholder="Select a Contributer"
+            values={["Robert Fund", "Sophie Fund", "Edward Fund"]}
+            width="95%"
+          ></Select>
+          <div className="mt-[32px] text-[22px]">Fund</div>
+          <Select
+            placeholder="Select a Fund"
+            values={["Sarah Clay", "Theo Rumberg", "Brandon Wu"]}
+            width="95%"
+          ></Select>
+          <div className="mb-2 mt-[32px] text-[22px]">Amount</div>
+          <Input
+            id="amount"
+            defaultValue="$"
+            className="mr-4 block w-[95%] rounded-lg border border-black px-2 py-3.5 text-sm text-gray-900 placeholder-gray-500 hover:bg-gray-100"
+          />
+          <div className="mb-2 mt-[32px] text-[22px]">Units purchased</div>
+          <Input
+            id="units purchased"
+            className="mr-4 block w-[95%] rounded-lg border border-gray-900 bg-gray-200 px-2 py-3.5 text-sm text-gray-900 placeholder-gray-500 hover:bg-gray-100"
+          />
+          <div className="mt-[32px] grid grid-cols-2">
             <div className="justify-start">
-                <div className="text-[22px]">Transaction</div>
-                <div className="ml-2"><Radio label="Deposit" ></Radio>
-                <Radio label="Withdrawl"></Radio></div>
+              <div className="text-[22px]">Transaction</div>
+              <div className="ml-2 mt-3 space-y-2 text-[22px]">
+                <Radio label="Deposit"></Radio>
+                <Radio label="Withdrawl"></Radio>
+              </div>
             </div>
             <div className="justify-start">
-                <div className="text-[22px]">Type</div>
-                <div className="ml-2"><Radio label="Deposit"></Radio>
-                <Radio label="Withdrawl"></Radio></div>
+              <div className="text-[22px]">Type</div>
+              <div className="ml-2 mt-3 space-y-2 text-[22px]">
+                <Radio label="Deposit"></Radio>
+                <Radio label="Withdrawl"></Radio>
+              </div>
             </div>
-        </div>
+          </div>
+          <div className="relative mt-[32px]">
+            <div className="absolute left-0 text-[22px]">Description</div>
+            <div className="absolute right-10 text-[22px] italic text-gray-300">
+              Optional
+            </div>
+          </div>
 
-            
-        <DialogFooter>
-            <Button variant = "primary">
+          <textarea
+            className="ml-0.5 mt-[42px] h-[150px] w-[95%] rounded-2xl border border-black"
+            placeholder="Add a description"
+            rows={4}
+            cols={40}
+          />
+          <div className="mt-[32px] text-[22px]">Additional documents</div>
+          <div className="relative mt-2">
+            <div className="absolute left-0 text-[18px] text-gray-300">
+              Upload a file (5MB max)
+            </div>
+            <div className="absolute right-10 text-[22px] italic text-gray-300">
+              Optional
+            </div>
+          </div>
+          <div className="mt-[46px] h-[51px] w-[95%] rounded-lg bg-gray-200"></div>
+          <div className="relative mt-[100px]">
+            <Button className="absolute left-0 mb-2 me-2 rounded-2xl border border-black px-16 py-3 text-lg text-black hover:bg-grey-dark focus:outline-none focus:ring-4 focus:ring-gray-300">
+              Cancel
+            </Button>
+            <Button className="absolute right-5 mb-2 me-2 rounded-2xl border border-black bg-gray-800 px-20 py-3 text-lg text-white hover:bg-grey-dark focus:outline-none focus:ring-4 focus:ring-gray-300">
               Add
-              </Button>
-          </DialogFooter>
-          </ScrollArea>
+            </Button>
+          </div>
+          <DialogFooter></DialogFooter>
+        </ScrollArea>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -5,7 +5,7 @@ import Input from "@/components/atoms/Input";
 import Radio from "@/components/atoms/Radio";
 import Select from "@/components/atoms/Select";
 import { ScrollArea } from "@/components/ui/scroll";
-import DatePicker from "@/components/atoms/DatePicker";
+import { DatePicker } from "@/components/atoms/DatePicker";
 import { Calendar } from "@/components/ui/calendar";
 
 import {
@@ -19,8 +19,6 @@ import {
 } from "@/components/ui/dialog";
 
 const TransactionModal = ({}) => {
-  const [date, setDate] = React.useState<Date | undefined>(new Date());
-
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -34,13 +32,8 @@ const TransactionModal = ({}) => {
             </DialogTitle>
           </DialogHeader>
           <div className="mb-2 text-[22px]">Date</div>
-          <div className="h-[51px] w-[268px] rounded-lg bg-gray-200">
-            <Calendar
-              mode="single"
-              selected={date}
-              onSelect={setDate}
-              className="rounded-md border"
-            />
+          <div>
+            <DatePicker></DatePicker>
           </div>
           <div className="mt-[32px] text-[22px]">Contributer</div>
           <Select

--- a/frontend/src/components/molecules/AddTransactionModal.tsx
+++ b/frontend/src/components/molecules/AddTransactionModal.tsx
@@ -70,8 +70,8 @@ const TransactionModal = ({}) => {
             <div className="justify-start">
               <div className="text-[22px]">Type</div>
               <div className="ml-2 mt-3 space-y-2 text-[22px]">
-                <Radio label="Deposit"></Radio>
-                <Radio label="Withdrawl"></Radio>
+                <Radio label="Donation"></Radio>
+                <Radio label="Endowment"></Radio>
               </div>
             </div>
           </div>
@@ -81,7 +81,6 @@ const TransactionModal = ({}) => {
               Optional
             </div>
           </div>
-
           <textarea
             className="ml-0.5 mt-[42px] h-[150px] w-[95%] rounded-2xl border border-black"
             placeholder="Add a description"

--- a/frontend/src/components/molecules/DragDrop.tsx
+++ b/frontend/src/components/molecules/DragDrop.tsx
@@ -26,9 +26,9 @@ const DragDrop = () => {
               >
                 <path
                   stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="1"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth="1"
                   d="M15 17h3a3 3 0 0 0 0-6h-.025a5.56 5.56 0 0 0 .025-.5A5.5 5.5 0 0 0 7.207 9.021C7.137 9.017 7.071 9 7 9a4 4 0 1 0 0 8h2.167M12 19v-9m0 0-2 2m2-2 2 2"
                 />
               </svg>

--- a/frontend/src/components/molecules/DragDrop.tsx
+++ b/frontend/src/components/molecules/DragDrop.tsx
@@ -1,0 +1,56 @@
+import { SetStateAction, useState } from "react";
+import { FileUploader } from "react-drag-drop-files";
+import UploadFileIcon from "@mui/icons-material/UploadFile";
+
+const fileTypes = ["JPEG", "PNG", "PDF"];
+
+const DragDrop = () => {
+  const [file, setFile] = useState(null);
+  const handleChange = (file: SetStateAction<null>) => {
+    setFile(file);
+  };
+  return (
+    <div className="mt-[50px] w-[95%]">
+      <FileUploader
+        children={
+          <div className="h-[150px] rounded-2xl border-2 border-dotted border-gray-500 bg-gray-100">
+            <div className="flex flex-col items-center justify-center">
+              <svg
+                className="align-center h-16 w-16 text-gray-800 dark:text-white"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                fill="none"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="1"
+                  d="M15 17h3a3 3 0 0 0 0-6h-.025a5.56 5.56 0 0 0 .025-.5A5.5 5.5 0 0 0 7.207 9.021C7.137 9.017 7.071 9 7 9a4 4 0 1 0 0 8h2.167M12 19v-9m0 0-2 2m2-2 2 2"
+                />
+              </svg>
+              <div className="text-center text-[22px] text-black">
+                Drop files here
+              </div>
+              <div className="text-extralight justify-center text-center text-[20px] text-gray-500">
+                or <span className="underline">select files</span>
+              </div>
+            </div>
+          </div>
+        }
+        label="Drop"
+        uploadedLabel="Upload Successful"
+        multiple={true}
+        handleChange={handleChange}
+        name="file"
+        hoverTitle="Drop"
+        types={fileTypes}
+      />
+    </div>
+  );
+};
+
+export default DragDrop;

--- a/frontend/src/components/ui/button.tsx
+++ b/frontend/src/components/ui/button.tsx
@@ -1,0 +1,56 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-destructive-foreground hover:bg-destructive/90",
+        outline:
+          "border border-input bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary:
+          "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-10 px-4 py-2",
+        sm: "h-9 rounded-md px-3",
+        lg: "h-11 rounded-md px-8",
+        icon: "h-10 w-10",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : "button"
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Button.displayName = "Button"
+
+export { Button, buttonVariants }

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -1,0 +1,66 @@
+"use client"
+
+import * as React from "react"
+import { ChevronLeft, ChevronRight } from "lucide-react"
+import { DayPicker } from "react-day-picker"
+
+import { cn } from "@/lib/utils"
+import { buttonVariants } from "@/components/ui/button"
+
+export type CalendarProps = React.ComponentProps<typeof DayPicker>
+
+function Calendar({
+  className,
+  classNames,
+  showOutsideDays = true,
+  ...props
+}: CalendarProps) {
+  return (
+    <DayPicker
+      showOutsideDays={showOutsideDays}
+      className={cn("p-3", className)}
+      classNames={{
+        months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
+        month: "space-y-4",
+        caption: "flex justify-center pt-1 relative items-center",
+        caption_label: "text-sm font-medium",
+        nav: "space-x-1 flex items-center",
+        nav_button: cn(
+          buttonVariants({ variant: "outline" }),
+          "h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+        ),
+        nav_button_previous: "absolute left-1",
+        nav_button_next: "absolute right-1",
+        table: "w-full border-collapse space-y-1",
+        head_row: "flex",
+        head_cell:
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+        row: "flex w-full mt-2",
+        cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
+        day: cn(
+          buttonVariants({ variant: "ghost" }),
+          "h-9 w-9 p-0 font-normal aria-selected:opacity-100"
+        ),
+        day_range_end: "day-range-end",
+        day_selected:
+          "bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground",
+        day_today: "bg-accent text-accent-foreground",
+        day_outside:
+          "day-outside text-muted-foreground aria-selected:bg-accent/50 aria-selected:text-muted-foreground",
+        day_disabled: "text-muted-foreground opacity-50",
+        day_range_middle:
+          "aria-selected:bg-accent aria-selected:text-accent-foreground",
+        day_hidden: "invisible",
+        ...classNames,
+      }}
+      components={{
+        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
+        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+      }}
+      {...props}
+    />
+  )
+}
+Calendar.displayName = "Calendar"
+
+export { Calendar }

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -1,13 +1,13 @@
-"use client"
+"use client";
 
-import * as React from "react"
-import { ChevronLeft, ChevronRight } from "lucide-react"
-import { DayPicker } from "react-day-picker"
+import * as React from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { DayPicker } from "react-day-picker";
 
-import { cn } from "@/lib/utils"
-import { buttonVariants } from "@/components/ui/button"
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 
-export type CalendarProps = React.ComponentProps<typeof DayPicker>
+export type CalendarProps = React.ComponentProps<typeof DayPicker>;
 
 function Calendar({
   className,
@@ -59,8 +59,8 @@ function Calendar({
       }}
       {...props}
     />
-  )
+  );
 }
-Calendar.displayName = "Calendar"
+Calendar.displayName = "Calendar";
 
-export { Calendar }
+export { Calendar };

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -20,6 +20,7 @@ function Calendar({
       showOutsideDays={showOutsideDays}
       className={cn("p-3", className)}
       classNames={{
+        selected: `bg-black border-black-500 text-white hover:text-white hover:bg-black`,
         months: "flex flex-col sm:flex-row space-y-4 sm:space-x-4 sm:space-y-0",
         month: "space-y-4",
         caption: "flex justify-center pt-1 relative items-center",
@@ -34,7 +35,7 @@ function Calendar({
         table: "w-full border-collapse space-y-1",
         head_row: "w-full flex justify-between",
         head_cell:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem] w-1/7",
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
         row: "flex w-full mt-2",
         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(

--- a/frontend/src/components/ui/calendar.tsx
+++ b/frontend/src/components/ui/calendar.tsx
@@ -32,9 +32,9 @@ function Calendar({
         nav_button_previous: "absolute left-1",
         nav_button_next: "absolute right-1",
         table: "w-full border-collapse space-y-1",
-        head_row: "flex",
+        head_row: "w-full flex justify-between",
         head_cell:
-          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem]",
+          "text-muted-foreground rounded-md w-9 font-normal text-[0.8rem] w-1/7",
         row: "flex w-full mt-2",
         cell: "h-9 w-9 text-center text-sm p-0 relative [&:has([aria-selected].day-range-end)]:rounded-r-md [&:has([aria-selected].day-outside)]:bg-accent/50 [&:has([aria-selected])]:bg-accent first:[&:has([aria-selected])]:rounded-l-md last:[&:has([aria-selected])]:rounded-r-md focus-within:relative focus-within:z-20",
         day: cn(
@@ -54,8 +54,22 @@ function Calendar({
         ...classNames,
       }}
       components={{
-        IconLeft: ({ ...props }) => <ChevronLeft className="h-4 w-4" />,
-        IconRight: ({ ...props }) => <ChevronRight className="h-4 w-4" />,
+        PreviousMonthButton: ({ ...props }) => (
+          <button
+            {...props}
+            className="h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </button>
+        ),
+        NextMonthButton: ({ ...props }) => (
+          <button
+            {...props}
+            className="absolute right-1 h-7 w-7 bg-transparent p-0 opacity-50 hover:opacity-100"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </button>
+        ),
       }}
       {...props}
     />

--- a/frontend/src/components/ui/dialog.tsx
+++ b/frontend/src/components/ui/dialog.tsx
@@ -38,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        `fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg`,
+        `fixed left-[50%] top-[50%] z-50 grid w-full max-w-full translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]`,
         className
       )}
       {...props}

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const ShadInput = React.forwardRef<
+  HTMLInputElement,
+  React.ComponentProps<"input">
+>(({ className, type, ...props }, ref) => {
+  return (
+    <input
+      type={type}
+      className={cn(
+        `flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm`,
+        className
+      )}
+      ref={ref}
+      {...props}
+    />
+  );
+});
+ShadInput.displayName = "Input";
+
+export { ShadInput };

--- a/frontend/src/components/ui/popover.tsx
+++ b/frontend/src/components/ui/popover.tsx
@@ -1,0 +1,31 @@
+"use client"
+
+import * as React from "react"
+import * as PopoverPrimitive from "@radix-ui/react-popover"
+
+import { cn } from "@/lib/utils"
+
+const Popover = PopoverPrimitive.Root
+
+const PopoverTrigger = PopoverPrimitive.Trigger
+
+const PopoverContent = React.forwardRef<
+  React.ElementRef<typeof PopoverPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <PopoverPrimitive.Portal>
+    <PopoverPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </PopoverPrimitive.Portal>
+))
+PopoverContent.displayName = PopoverPrimitive.Content.displayName
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/frontend/src/components/ui/radiogroup.tsx
+++ b/frontend/src/components/ui/radiogroup.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import * as React from "react";
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group";
+import { Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const RadioGroup = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Root
+      className={cn("grid gap-2", className)}
+      {...props}
+      ref={ref}
+    />
+  );
+});
+RadioGroup.displayName = RadioGroupPrimitive.Root.displayName;
+
+const RadioGroupItem = React.forwardRef<
+  React.ElementRef<typeof RadioGroupPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof RadioGroupPrimitive.Item>
+>(({ className, ...props }, ref) => {
+  return (
+    <RadioGroupPrimitive.Item
+      ref={ref}
+      className={cn(
+        `aspect-square h-6 w-6 rounded-full border border-primary text-primary ring-offset-background focus:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50`,
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator className="flex items-center justify-center">
+        <Circle className="text-current h-4 w-4 fill-black" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  );
+});
+RadioGroupItem.displayName = RadioGroupPrimitive.Item.displayName;
+
+export { RadioGroup, RadioGroupItem };

--- a/frontend/src/components/ui/scroll.tsx
+++ b/frontend/src/components/ui/scroll.tsx
@@ -1,0 +1,48 @@
+"use client"
+ 
+import * as React from "react"
+import * as ScrollAreaPrimitive from "@radix-ui/react-scroll-area"
+ 
+import { cn } from "@/lib/utils"
+ 
+const ScrollArea = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
+>(({ className, children, ...props }, ref) => (
+  <ScrollAreaPrimitive.Root
+    ref={ref}
+    className={cn("relative overflow-hidden", className)}
+    {...props}
+  >
+    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+      {children}
+    </ScrollAreaPrimitive.Viewport>
+    <ScrollBar />
+    <ScrollAreaPrimitive.Corner />
+  </ScrollAreaPrimitive.Root>
+))
+ScrollArea.displayName = ScrollAreaPrimitive.Root.displayName
+ 
+const ScrollBar = React.forwardRef<
+  React.ElementRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>,
+  React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.ScrollAreaScrollbar>
+>(({ className, orientation = "vertical", ...props }, ref) => (
+  <ScrollAreaPrimitive.ScrollAreaScrollbar
+    ref={ref}
+    orientation={orientation}
+    className={cn(
+      "flex touch-none select-none transition-colors",
+      orientation === "vertical" &&
+        "h-full w-2.5 border-l border-l-transparent p-[1px]",
+      orientation === "horizontal" &&
+        "h-2.5 flex-col border-t border-t-transparent p-[1px]",
+      className
+    )}
+    {...props}
+  >
+    <ScrollAreaPrimitive.ScrollAreaThumb className="relative flex-1 rounded-full bg-border" />
+  </ScrollAreaPrimitive.ScrollAreaScrollbar>
+))
+ScrollBar.displayName = ScrollAreaPrimitive.ScrollAreaScrollbar.displayName
+ 
+export { ScrollArea, ScrollBar }

--- a/frontend/src/components/ui/select.tsx
+++ b/frontend/src/components/ui/select.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import * as React from "react";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check, ChevronDown, ChevronUp } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const Select = SelectPrimitive.Root;
+
+const SelectGroup = SelectPrimitive.Group;
+
+const SelectValue = SelectPrimitive.Value;
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      `flex h-10 w-full items-center justify-between rounded-md bg-gray-100 px-3 py-2 text-sm placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1`,
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <ChevronDown className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+));
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUp className="h-4 w-4" />
+  </SelectPrimitive.ScrollUpButton>
+));
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDown className="h-4 w-4" />
+  </SelectPrimitive.ScrollDownButton>
+));
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName;
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        `relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2`,
+        position === "popper" &&
+          `data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1`,
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            `h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]`
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+));
+SelectContent.displayName = SelectPrimitive.Content.displayName;
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("py-1.5 pl-8 pr-2 text-sm font-semibold", className)}
+    {...props}
+  />
+));
+SelectLabel.displayName = SelectPrimitive.Label.displayName;
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      `relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50`,
+      className
+    )}
+    {...props}
+  >
+    <span
+      className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center"
+    >
+      <SelectPrimitive.ItemIndicator>
+        <Check className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+));
+SelectItem.displayName = SelectPrimitive.Item.displayName;
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+};

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,31 @@
+"use client"
+ 
+import * as React from "react"
+import * as SeparatorPrimitive from "@radix-ui/react-separator"
+ 
+import { cn } from "@/lib/utils"
+ 
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = "horizontal", decorative = true, ...props },
+    ref
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border",
+        orientation === "horizontal" ? "h-[1px] w-full" : "h-full w-[1px]",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Separator.displayName = SeparatorPrimitive.Root.displayName
+ 
+export { Separator }


### PR DESCRIPTION
## Summary

Create add transaction modal that allows users to enter details about a transaction. Includes components such as date picker, file drag and drop, text fields, and drop down selections. 

## Testing

We tested the code by putting the modal component into test/modaltest and opening the modal by clicking add transaction. We tested each component in the modal by entering and selecting information accordingly. 
<img width="716" alt="image" src="https://github.com/user-attachments/assets/7a8efd40-fa1d-43a0-82f1-e8badc4cc90b">
<img width="973" alt="image" src="https://github.com/user-attachments/assets/c8adf89e-f863-45ef-9b95-c3f6d4eb40d9">
<img width="869" alt="image" src="https://github.com/user-attachments/assets/8e4f97df-63ac-4a1c-9cd4-69b8065db945">
<img width="590" alt="image" src="https://github.com/user-attachments/assets/03f8b307-885a-44fc-b8b0-f73b46adedde">
<img width="618" alt="image" src="https://github.com/user-attachments/assets/38665b2e-b078-4cd7-bc3b-8bdcdd146753">
<img width="630" alt="image" src="https://github.com/user-attachments/assets/bd42cba4-bccb-4968-8ea3-f86bc360b75b">
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/262b0a78-58bc-4cbf-8387-7a39cf54d359">


## Notes

There is one styling bug we are trying to fix with the calendar component where the Sunday label is extended to the full length of the calendar, offsetting the rest of the labels. 
<img width="485" alt="image" src="https://github.com/user-attachments/assets/34669318-2de3-468f-b783-e30aab2c9c30">
