### PR TITLE
Add Funds Modal

### DIFF
--- a/frontend/src/app/funds/page.tsx
+++ b/frontend/src/app/funds/page.tsx
@@ -35,6 +35,7 @@ const FundsPage = () => {
           No funds to display yet.
         </div>
         <FundsTable />
+      </div>
     </DashboardTemplate>
   );
 };

--- a/frontend/src/app/funds/page.tsx
+++ b/frontend/src/app/funds/page.tsx
@@ -1,10 +1,39 @@
 "use client";
+
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
+import AddFundModal from "@/components/molecules/AddFundModal";
+import React from "react";
+import AddIcon from "@mui/icons-material/Add";
+import Button from "@/components/atoms/Button";
 
 const FundsPage = () => {
   return (
     <DashboardTemplate>
-      <div>Funds Page</div>
+      <div className="flex flex-col px-8 py-6">
+        {/* Top section with heading and Add Fund button */}
+        <div className="mb-12 flex items-center justify-between">
+          <h1 className="text-3xl">Funds</h1>
+          <AddFundModal>
+            <Button
+              variant="primary"
+              style={{
+                display: "flex",
+                alignItems: "center",
+                height: "40px",
+                padding: "0 16px",
+              }}
+            >
+              Add Fund
+              <AddIcon style={{ marginLeft: "6px" }} />
+            </Button>
+          </AddFundModal>
+        </div>
+
+        {/* Placeholder for future fund table */}
+        <div className="text-gray-500 pl-1 text-left text-lg">
+          No funds to display yet.
+        </div>
+      </div>
     </DashboardTemplate>
   );
 };

--- a/frontend/src/components/molecules/AddFundModal.tsx
+++ b/frontend/src/components/molecules/AddFundModal.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import React, { ReactNode, useState } from "react";
+import Input from "@/components/atoms/Input";
+import Button from "@/components/atoms/Button";
+import { ScrollArea } from "@/components/ui/scroll";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Label } from "@/components/ui/label";
+
+type AddFundModalProps = {
+  children: ReactNode;
+};
+
+const AddFundModal: React.FC<AddFundModalProps> = ({ children }) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [type, setType] = useState("donation");
+  const [restriction, setRestriction] = useState("restricted");
+  const [description, setDescription] = useState("");
+
+  const handleAdd = () => {
+    console.log({
+      name,
+      type,
+      restriction,
+      description,
+    });
+    setIsOpen(false);
+  };
+
+  const handleCancel = () => {
+    setIsOpen(false);
+  };
+
+  return (
+    <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <DialogTrigger asChild onClick={() => setIsOpen(true)}>
+        {children}
+      </DialogTrigger>
+      <DialogContent className="h-auto w-[700px] rounded-[40px] px-[80px] pb-[40px] pt-[60px]">
+        <ScrollArea className="h-full w-full">
+          <DialogHeader>
+            <DialogTitle className="mb-[32px] text-[28px]">
+              Add Fund
+            </DialogTitle>
+          </DialogHeader>
+
+          {/* Name Field */}
+          <div className="mb-6">
+            <Label htmlFor="name" className="mb-2 block text-lg">
+              Name
+            </Label>
+            <Input
+              id="name"
+              placeholder="Add a name"
+              value={name}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setName(e.target.value)
+              }
+            />
+          </div>
+
+          {/* Type Field (vertical layout) */}
+          <div className="mb-6">
+            <Label className="mb-2 block text-lg">Type</Label>
+            <RadioGroup
+              value={type}
+              onValueChange={setType}
+              className="flex flex-col gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="donation" id="donation" />
+                <Label htmlFor="donation">Donation</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="endowment" id="endowment" />
+                <Label htmlFor="endowment">Endowment</Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {/* Restriction Field (vertical layout) */}
+          <div className="mb-6">
+            <Label className="mb-2 block text-lg">Restriction</Label>
+            <RadioGroup
+              value={restriction}
+              onValueChange={setRestriction}
+              className="flex flex-col gap-2"
+            >
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="restricted" id="restricted" />
+                <Label htmlFor="restricted">Restricted</Label>
+              </div>
+              <div className="flex items-center gap-2">
+                <RadioGroupItem value="unrestricted" id="unrestricted" />
+                <Label htmlFor="unrestricted">Unrestricted</Label>
+              </div>
+            </RadioGroup>
+          </div>
+
+          {/* Description Field */}
+          <div className="mb-6">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="description" className="text-lg">
+                Description
+              </Label>
+              <span className="text-gray-300 text-sm">Optional</span>
+            </div>
+            <Input
+              id="description"
+              placeholder="Add a Description"
+              value={description}
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                setDescription(e.target.value)
+              }
+              className="border-gray-300 h-32 w-full resize-none rounded-lg border-[1px] px-4 py-2 text-left" // Ensures left-aligned text
+              as="textarea"
+            />
+          </div>
+          {/* Footer Buttons */}
+          <DialogFooter className="mt-8 flex items-center justify-between">
+            <Button variant="secondary" onClick={handleCancel}>
+              Cancel
+            </Button>
+            <Button
+              style={{ backgroundColor: "black", color: "white" }}
+              onClick={handleAdd}
+            >
+              Add
+            </Button>
+          </DialogFooter>
+        </ScrollArea>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AddFundModal;

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,15 @@
+// path: /components/ui/label.tsx
+import React from "react";
+
+type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>;
+
+const Label = ({ className = "", ...props }: LabelProps) => {
+  return (
+    <label
+      {...props}
+      className={`block mb-2 text-lg font-medium text-gray-900 ${className}`}
+    />
+  );
+};
+
+export { Label };


### PR DESCRIPTION
## Summary

Created a frontend modal component for adding funds. The modal includes fields for entering the fund name, selecting its type (donation or endowment), setting its restriction (restricted or unrestricted), and adding an optional description. The modal is designed to be similar in functionality to the "Add Transactions" button and is styled to match the provided designs.

No backend functionality or integrations are connected at this stage; the modal is purely for frontend use.

## Testing

- Manual testing was performed by interacting with the modal UI to ensure:
  - The modal opens and closes correctly when triggered.
  - All form fields are displayed as expected, including the name, type, restriction, and description.
  - The form inputs handle text changes correctly.
  - The cancel and add buttons perform the expected actions.
- All UI components (buttons, inputs, radio buttons) are clickable and interactable.

To test:
1. Run `yarn run dev`
2. Trigger the modal by clicking the button that opens it.
3. Enter values in the name, type, restriction, and description fields.
4. Click "Add" to log the values or "Cancel" to close the modal without any changes.

## Notes

![Screenshot 2025-04-10 160711](https://github.com/user-attachments/assets/7d497d3a-f456-4121-9629-d07831a272cd)
![Screenshot 2025-04-10 160718](https://github.com/user-attachments/assets/f835b08c-5f56-4436-90f8-fa97b713e69c)

During last work session, you said not to worry about the edits mentioned in our issue about editing the add transactions modal due to some Figma complications, so we didn't do that.