### PR TITLE
Akhil jade/funds endpoints

### DIFF
--- a/backend/src/controllers/funds.ts
+++ b/backend/src/controllers/funds.ts
@@ -55,32 +55,27 @@ const getFundById = async (id: string): Promise<Fund | null> => {
 
 // TODO: update new fund
 
-// TODO: delete new fund - akhil jade
 const deleteFundById = async (id: string): Promise<Fund | null> => {
   try {
-    const fund = await prisma.fund.findUnique({ where: { id },});
+    const fund = await prisma.fund.findUnique({ where: { id } });
     // check if fund exists
     if (!fund) return null;
 
     // delete related transactions
     await prisma.transaction.deleteMany({
-      where: {fundId : id},
+      where: { fundId: id },
     });
 
     // delete fund
-    return await prisma.fund.delete({ where : { id } });
-
+    return await prisma.fund.delete({ where: { id } });
   } catch (error) {
     if (error instanceof Error) {
       throw new Error(`Failed to delete fund: ${error.message}`);
     }
     throw new Error("Failed to delete fund due to an unknown error");
   }
-  
 };
 
-
-// TODO: get all transactions by fund id - akhil jade
 const getTransactionsByFundId = async (
   id: string,
   //sort based on either first name, last name, in ascending or descending order
@@ -133,5 +128,5 @@ export default {
   getFunds,
   getFundById,
   getTransactionsByFundId,
-  deleteFundById
+  deleteFundById,
 };

--- a/backend/src/routes/funds.ts
+++ b/backend/src/routes/funds.ts
@@ -46,14 +46,13 @@ fundRouter.put("/:id", async (req, res) => {
   // implement route here
 });
 
-// TODO: delete new fund
 fundRouter.delete("/:id", async (req, res) => {
   try {
     const fund = await controller.deleteFundById(req.params.id);
     if (!fund) {
       return res.status(404).json({ error: "Fund not found" });
     }
-    res.status(200).json({ message : "Fund deleted"});
+    res.status(200).json({ message: "Fund deleted" });
   } catch (error) {
     console.error(error);
     const errorResponse: ErrorMessage = {
@@ -63,8 +62,6 @@ fundRouter.delete("/:id", async (req, res) => {
   }
 });
 
-
-// TODO: get all transactions by fund id
 fundRouter.get("/:id/transactions", async (req, res) => {
   try {
     // Get inputs


### PR DESCRIPTION
## Summary

In `src/controllers/funds.ts`, we implemented `getTransactionsByFundId` (selects all transactions associated with a fund ID), and `deleteFundById` (deletes a fund by ID). 

Like existing functions, `getTransactionsByFundId` has correct appropriate pagination, sorting, and validation. `deleteFundById' also has validation. 

In `src/routes/funds.ts`, we implemented the appropriate routes, where `id` refers to fund ID:

- DELETE `/funds/{id}`
- GET `/funds/{id}/transactions`

## Testing

We tested these route with Postman. Since createFundID wasn't implemented, we couldn't verify the validity of sorting/pagination on `getTransactionsByFundId`, but it is set up like existing functions which have been tested.

### Transactions by Fund Id
<img width="837" height="668" alt="image" src="https://github.com/user-attachments/assets/54c71b64-00e4-4d93-bec6-85df955e1872" />

### Delete

Postman
<img width="883" height="685" alt="Screenshot 2025-09-17 at 1 58 32 PM" src="https://github.com/user-attachments/assets/93f912b2-5151-410d-8c51-db95a138d153" />

Before
<img width="1401" height="367" alt="Screenshot 2025-09-17 at 1 58 18 PM" src="https://github.com/user-attachments/assets/703cdb61-5d3c-42b9-aa19-fb6a4620d458" />

After
<img width="1381" height="323" alt="Screenshot 2025-09-17 at 1 58 38 PM" src="https://github.com/user-attachments/assets/7c691220-293d-4b1a-9a51-9493571b36a0" />
