### PR TITLE
Scope transaction and contributor endpoints to caller's org

### DIFF
--- a/backend/src/routes/contributors.ts
+++ b/backend/src/routes/contributors.ts
@@ -60,16 +60,25 @@ contributorRouter.get("/", auth, async (req, res) => {
 });
 
 // GET a single contributor by ID
-contributorRouter.get("/:id", async (req, res) => {
+contributorRouter.get("/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const { id } = req.params;
     const contributor = await controller.getContributorById(id);
 
-    if (contributor) {
-      res.status(200).json(contributor);
-    } else {
-      res.status(404).json({ error: "Contributor not found" });
+    if (!contributor) {
+      return res.status(404).json({ error: "Contributor not found" });
     }
+    if (contributor.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+    res.status(200).json(contributor);
   } catch (error) {
     console.error(error);
     const errorResponse: ErrorMessage = {
@@ -81,9 +90,16 @@ contributorRouter.get("/:id", async (req, res) => {
 });
 
 // POST a new contributor
-contributorRouter.post("/", async (req, res) => {
+contributorRouter.post("/", auth, async (req, res) => {
   try {
-    const contributorData = req.body;
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
+    const contributorData = { ...req.body, organizationId: user.organizationId };
 
     if (!contributorData.firstName || !contributorData.lastName) {
       return res.status(400).json({
@@ -104,15 +120,27 @@ contributorRouter.post("/", async (req, res) => {
 });
 
 // PUT (update) an existing contributor
-contributorRouter.put("/:id", async (req, res) => {
+contributorRouter.put("/:id", auth, async (req, res) => {
   const id = req.params.id;
-  const contributorData = req.body;
 
   try {
-    const updatedContributor = await controller.updateContributor(
-      id,
-      contributorData
-    );
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
+    const existing = await controller.getContributorById(id);
+    if (!existing) {
+      return res.status(404).json({ error: "Contributor not found" });
+    }
+    if (existing.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
+    const { organizationId: _stripped, ...contributorData } = req.body;
+    const updatedContributor = await controller.updateContributor(id, contributorData);
     res.status(200).json(updatedContributor);
   } catch (error) {
     console.error(error);
@@ -125,9 +153,24 @@ contributorRouter.put("/:id", async (req, res) => {
 });
 
 // DELETE a contributor
-contributorRouter.delete("/:id", async (req, res) => {
+contributorRouter.delete("/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const { id } = req.params;
+    const existing = await controller.getContributorById(id);
+    if (!existing) {
+      return res.status(404).json({ error: "Contributor not found" });
+    }
+    if (existing.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
     const deletedContributor = await controller.deleteContributor(id);
     res.status(200).json(deletedContributor);
   } catch (error) {
@@ -141,8 +184,23 @@ contributorRouter.delete("/:id", async (req, res) => {
 });
 
 // get all transactions of contributor
-contributorRouter.get("/:id/transactions", async (req, res) => {
+contributorRouter.get("/:id/transactions", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
+    const existing = await controller.getContributorById(req.params.id);
+    if (!existing) {
+      return res.status(404).json({ error: "Contributor not found" });
+    }
+    if (existing.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
     const transactions = await orgController.getOrganizationTransactions(
       req.params.id
     );

--- a/backend/src/routes/transactions.ts
+++ b/backend/src/routes/transactions.ts
@@ -70,16 +70,25 @@ transactionRouter.get("/", auth, async (req, res) => {
 });
 
 /** GET /transactions/:id Retrieves a single transaction by its ID. */
-transactionRouter.get("/:id", async (req, res) => {
+transactionRouter.get("/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const { id } = req.params;
     const transaction = await controller.getTransactionById(id);
 
-    if (transaction) {
-      res.status(200).json(transaction);
-    } else {
-      res.status(404).json({ error: "Transaction not found" });
+    if (!transaction) {
+      return res.status(404).json({ error: "Transaction not found" });
     }
+    if (transaction.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+    res.status(200).json(transaction);
   } catch (error) {
     console.error(error);
     const errorResponse: ErrorMessage = {
@@ -94,14 +103,26 @@ transactionRouter.get("/:id", async (req, res) => {
  * PUT /transactions/:id Updates an existing transaction with the data provided
  * in the request body.
  */
-transactionRouter.put("/:id", async (req, res) => {
+transactionRouter.put("/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const { id } = req.params;
-    const updateData = req.body;
-    const updatedTransaction = await controller.updateTransaction(
-      id,
-      updateData
-    );
+    const existing = await controller.getTransactionById(id);
+    if (!existing) {
+      return res.status(404).json({ error: "Transaction not found" });
+    }
+    if (existing.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
+    const { organizationId: _stripped, ...updateData } = req.body;
+    const updatedTransaction = await controller.updateTransaction(id, updateData);
     res.status(200).json(updatedTransaction);
   } catch (error) {
     console.error(error);
@@ -153,13 +174,19 @@ transactionRouter.post("/bulk", auth, async (req, res) => {
 });
 
 // POST /transactions route
-transactionRouter.post("/", async (req, res) => {
+transactionRouter.post("/", auth, async (req, res) => {
   try {
-    const transactionData = req.body;
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
+    const transactionData = { ...req.body, organizationId: user.organizationId };
 
     // Basic validation (units and description are optional)
     if (
-      !transactionData.organizationId ||
       !transactionData.contributorId ||
       !transactionData.fundId ||
       !transactionData.type ||
@@ -168,7 +195,7 @@ transactionRouter.post("/", async (req, res) => {
     ) {
       return res.status(400).json({
         error:
-          "Transaction organization ID, contributor ID, fund ID, type, date, and amount are required",
+          "Transaction contributor ID, fund ID, type, date, and amount are required",
       });
     }
 
@@ -185,9 +212,24 @@ transactionRouter.post("/", async (req, res) => {
 });
 
 // DELETE /transactions/:id route
-transactionRouter.delete("/:id", async (req, res) => {
+transactionRouter.delete("/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const id = req.params.id;
+    const existing = await controller.getTransactionById(id);
+    if (!existing) {
+      return res.status(404).json({ error: "Transaction not found" });
+    }
+    if (existing.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
     const deletedTransaction = await controller.deleteTransaction(id);
     res.status(200).json(deletedTransaction);
     notify(`/transactions/${id}`);
@@ -201,11 +243,21 @@ transactionRouter.delete("/:id", async (req, res) => {
   }
 });
 
-/* GET /transactions/:id/organizations route. Retrieves all transactions of an 
+/* GET /transactions/:id/organizations route. Retrieves all transactions of an
 organization with organizationId [id] */
-transactionRouter.get("/organizations/:id", async (req, res) => {
+transactionRouter.get("/organizations/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const { id } = req.params;
+    if (id !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
 
     const filters = {
       type: req.query.type as TransactionType | undefined,
@@ -260,12 +312,30 @@ transactionRouter.get("/organizations/:id", async (req, res) => {
 
 /* GET /transactions/contributors/:id route. Retrieves all transactions of
 a contributor with contributorId [id] */
-transactionRouter.get("/contributors/:id", async (req, res) => {
+transactionRouter.get("/contributors/:id", auth, async (req, res) => {
   try {
+    const firebaseUid = (req as any).auth.uid;
+    const user = await prisma.user.findUnique({
+      where: { firebaseUid },
+      select: { organizationId: true },
+    });
+    if (!user) return res.status(401).json({ error: "User not found" });
+
     const { id } = req.params;
+    const contributor = await prisma.contributor.findUnique({
+      where: { id },
+      select: { organizationId: true },
+    });
+    if (!contributor) {
+      return res.status(404).json({ error: "Contributor not found" });
+    }
+    if (contributor.organizationId !== user.organizationId) {
+      return res.status(403).json({ error: "Forbidden" });
+    }
+
     const filters = {
       type: req.query.type as string | undefined,
-      organizationId: req.query.organizationId as string | undefined,
+      organizationId: user.organizationId,
       startDate: req.query.startDate as string | undefined,
       endDate: req.query.endDate as string | undefined,
     };

--- a/frontend/src/app/activity/add-csv/page.tsx
+++ b/frontend/src/app/activity/add-csv/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState, useRef, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";

--- a/frontend/src/app/activity/add-multiple/page.tsx
+++ b/frontend/src/app/activity/add-multiple/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import React, { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { Suspense, useRef, useState, useEffect } from "react";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import TransactionsTable from "@/components/molecules/TransactionsTable";

--- a/frontend/src/app/contributors/page.tsx
+++ b/frontend/src/app/contributors/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState } from "react";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import ContributorsTable from "@/components/molecules/ContributorsTable";

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,4 +1,6 @@
 "use client";
+
+export const dynamic = "force-dynamic";
 import React, { useEffect, useState } from "react";
 import api from "@/utils/api";
 import TransactionsTable from "@/components/molecules/TransactionsTable";

--- a/frontend/src/app/funds/page.tsx
+++ b/frontend/src/app/funds/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState } from "react";
 import * as React from "react";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,4 +1,6 @@
 "use client";
+
+export const dynamic = "force-dynamic";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import React, { useEffect, useState } from "react";
 import Switch from '@mui/material/Switch';

--- a/frontend/src/app/settings/page.tsx
+++ b/frontend/src/app/settings/page.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+export const dynamic = "force-dynamic";
+
 import { useEffect, useState } from 'react';
 import DashboardTemplate from '@/components/templates/DashboardTemplate';
 import auth from '@/utils/firebase-client';

--- a/frontend/src/app/test/authtest/page.tsx
+++ b/frontend/src/app/test/authtest/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import { useState } from "react";
 import { signUpThenLoginFlow } from "./test_auth";
 import {

--- a/frontend/src/app/test/page.tsx
+++ b/frontend/src/app/test/page.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+export const dynamic = "force-dynamic";
+
 import React from "react";
 import { DashboardTemplate } from "@/components";
 

--- a/frontend/src/utils/firebase-client.ts
+++ b/frontend/src/utils/firebase-client.ts
@@ -1,9 +1,8 @@
 "use client";
 
-import { initializeApp } from "firebase/app";
+import { initializeApp, getApps, getApp } from "firebase/app";
 import { getAuth } from "firebase/auth";
 
-/** Firebase config */
 const firebaseConfig = {
   apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
   authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
@@ -14,10 +13,14 @@ const firebaseConfig = {
   measurementId: process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
 };
 
-/** Firebase app */
-const app = initializeApp(firebaseConfig);
+const app =
+  typeof window !== "undefined"
+    ? getApps().length
+      ? getApp()
+      : initializeApp(firebaseConfig)
+    : null;
 
-/** Auth instance associated with the created Firebase App */
-const auth = getAuth(app);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const auth = app ? getAuth(app) : (null as any);
 
 export default auth;


### PR DESCRIPTION
All individual-record endpoints for transactions and contributors lacked authentication and org ownership checks, allowing any authenticated user to read or mutate records belonging to other organizations. This PR extends the existing org-scoping pattern (already used on list endpoints) to every GET/POST/PUT/DELETE route.

Changes:

Added auth middleware to all previously unprotected endpoints in routes/transactions.ts and routes/contributors.ts
After authenticating, resolves the caller's organizationId via Firebase UID → Prisma User lookup and verifies it matches the target record before allowing access or mutation (returns 403 otherwise)
POST endpoints now set organizationId from the token, ignoring any client-supplied value
PUT endpoints strip organizationId from the request body to prevent callers from reassigning records to another org
GET /transactions/organizations/:id now returns 403 if the path param doesn't match the caller's own org
GET /transactions/contributors/:id verifies contributor ownership and forces the org filter from the token
Testing

Manual testing with two separate user accounts (Org A and Org B):

GET /transactions/:id with Org B's transaction ID as Org A → 403
PUT /transactions/:id on Org B's transaction as Org A → 403
DELETE /transactions/:id on Org B's transaction as Org A → 403
GET /transactions/organizations/:orgBId as Org A → 403
Same checks for all contributor endpoints
Unauthenticated requests to all modified endpoints → 401
Happy path: each user can still fully CRUD their own org's records
Notes

This is part of the broader data visibility scoping initiative. Future PRs may add org-scoping to fund endpoints and any other remaining unprotected routes.