### PR TITLE
Nathnael big changes (Frontend Redesign & Internal Dashboard Improvements)

### DIFF
--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -53,42 +53,68 @@ async function main() {
     },
   });
 
-  // Contributors
-  const alice = await prisma.contributor.create({
-    data: {
+  // Contributors (upsert by fixed id so re-runs are safe)
+  const alice = await prisma.contributor.upsert({
+    where: { id: "seed-contributor-alice" },
+    update: {},
+    create: {
+      id: "seed-contributor-alice",
       firstName: "Alice",
       lastName: "Johnson",
-      organization: { connect: { id: org.id } },
+      organizationId: org.id,
     },
   });
 
-  const bob = await prisma.contributor.create({
-    data: {
+  const bob = await prisma.contributor.upsert({
+    where: { id: "seed-contributor-bob" },
+    update: {},
+    create: {
+      id: "seed-contributor-bob",
       firstName: "Bob",
       lastName: "Smith",
-      organization: { connect: { id: org.id } },
+      organizationId: org.id,
     },
   });
 
-  const carol = await prisma.contributor.create({
-    data: {
+  const carol = await prisma.contributor.upsert({
+    where: { id: "seed-contributor-carol" },
+    update: {},
+    create: {
+      id: "seed-contributor-carol",
       firstName: "Carol",
       lastName: "Williams",
-      organization: { connect: { id: org.id } },
+      organizationId: org.id,
     },
   });
 
-  const david = await prisma.contributor.create({
-    data: {
+  const david = await prisma.contributor.upsert({
+    where: { id: "seed-contributor-david" },
+    update: {},
+    create: {
+      id: "seed-contributor-david",
       firstName: "David",
       lastName: "Lee",
-      organization: { connect: { id: org.id } },
+      organizationId: org.id,
     },
   });
 
-  // Funds
-  const generalFund = await prisma.fund.create({
-    data: {
+  const sarah = await prisma.contributor.upsert({
+    where: { id: "seed-contributor-sarah" },
+    update: {},
+    create: {
+      id: "seed-contributor-sarah",
+      firstName: "Sarah",
+      lastName: "Clay",
+      organizationId: org.id,
+    },
+  });
+
+  // Funds (upsert by fixed id)
+  const generalFund = await prisma.fund.upsert({
+    where: { id: "seed-fund-general" },
+    update: {},
+    create: {
+      id: "seed-fund-general",
       name: "General Scholarship Fund",
       description: "Unrestricted donations for general scholarships",
       organizationId: org.id,
@@ -96,12 +122,17 @@ async function main() {
       restriction: false,
       amount: 0,
       units: 0,
-      contributors: { connect: [{ id: alice.id }, { id: bob.id }, { id: carol.id }] },
+      contributors: {
+        connect: [{ id: alice.id }, { id: bob.id }, { id: carol.id }, { id: sarah.id }],
+      },
     },
   });
 
-  const endowmentFund = await prisma.fund.create({
-    data: {
+  const endowmentFund = await prisma.fund.upsert({
+    where: { id: "seed-fund-endowment" },
+    update: {},
+    create: {
+      id: "seed-fund-endowment",
       name: "Endowment Growth Fund",
       description: "Long-term endowment for capital growth",
       organizationId: org.id,
@@ -111,12 +142,15 @@ async function main() {
       rate: 0.05,
       amount: 0,
       units: 0,
-      contributors: { connect: [{ id: alice.id }, { id: david.id }] },
+      contributors: { connect: [{ id: alice.id }, { id: david.id }, { id: sarah.id }] },
     },
   });
 
-  const techFund = await prisma.fund.create({
-    data: {
+  const techFund = await prisma.fund.upsert({
+    where: { id: "seed-fund-tech" },
+    update: {},
+    create: {
+      id: "seed-fund-tech",
       name: "Technology Initiative Fund",
       description: "Funding for tech programs and infrastructure",
       organizationId: org.id,
@@ -124,12 +158,17 @@ async function main() {
       restriction: false,
       amount: 0,
       units: 0,
-      contributors: { connect: [{ id: bob.id }, { id: carol.id }, { id: david.id }] },
+      contributors: {
+        connect: [{ id: bob.id }, { id: carol.id }, { id: david.id }],
+      },
     },
   });
 
-  const researchFund = await prisma.fund.create({
-    data: {
+  const researchFund = await prisma.fund.upsert({
+    where: { id: "seed-fund-research" },
+    update: {},
+    create: {
+      id: "seed-fund-research",
       name: "Research Endowment",
       description: "Restricted endowment for academic research",
       organizationId: org.id,
@@ -139,11 +178,11 @@ async function main() {
       rate: 0.04,
       amount: 0,
       units: 0,
-      contributors: { connect: [{ id: carol.id }, { id: david.id }] },
+      contributors: { connect: [{ id: carol.id }, { id: david.id }, { id: sarah.id }] },
     },
   });
 
-  // Transactions — spread over the past 6 months
+  // Transactions — upsert by fixed id, spread across 12 months
   const d = (monthsAgo: number, day: number) => {
     const date = new Date();
     date.setMonth(date.getMonth() - monthsAgo);
@@ -151,43 +190,127 @@ async function main() {
     return date;
   };
 
-  // General Fund transactions
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: generalFund.id, contributorId: alice.id, type: TransactionType.DONATION, date: d(5, 3), amount: 2000, description: "Annual scholarship donation" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: generalFund.id, contributorId: bob.id, type: TransactionType.DONATION, date: d(4, 15), amount: 1500, description: "Spring donation" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: generalFund.id, contributorId: carol.id, type: TransactionType.DONATION, date: d(3, 8), amount: 3000, description: "Major gift" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: generalFund.id, contributorId: alice.id, type: TransactionType.EXPENSE, date: d(2, 20), amount: 800, description: "Scholarship disbursement Q1" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: generalFund.id, contributorId: bob.id, type: TransactionType.WITHDRAWAL, date: d(1, 10), amount: 500, description: "Program operating costs" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: generalFund.id, contributorId: carol.id, type: TransactionType.DONATION, date: d(0, 5), amount: 1000, description: "Recent donation" } });
+  // Helper for years ago
+  const y = (yearsAgo: number, month: number, day: number) => {
+    const date = new Date();
+    date.setFullYear(date.getFullYear() - yearsAgo);
+    date.setMonth(month - 1);
+    date.setDate(day);
+    return date;
+  };
 
-  // Endowment Fund transactions
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: endowmentFund.id, contributorId: alice.id, type: TransactionType.DONATION, date: d(5, 10), amount: 5000, description: "Founding endowment gift" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: endowmentFund.id, contributorId: david.id, type: TransactionType.DONATION, date: d(4, 2), amount: 10000, description: "Major endowment contribution" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: endowmentFund.id, contributorId: alice.id, type: TransactionType.INVESTMENT, date: d(3, 18), amount: 3000, description: "Quarterly investment allocation" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: endowmentFund.id, contributorId: david.id, type: TransactionType.INVESTMENT, date: d(1, 22), amount: 2000, description: "Reinvestment of returns" } });
+  const transactions: {
+    id: string;
+    organizationId: string;
+    fundId: string;
+    contributorId: string;
+    type: TransactionType;
+    date: Date;
+    amount: number;
+    description: string;
+  }[] = [
+    // --- General Scholarship Fund ---
+    { id: "tx-001", organizationId: org.id, fundId: generalFund.id, contributorId: alice.id,   type: TransactionType.DONATION,    date: d(11, 3),  amount: 2000,  description: "Annual scholarship donation" },
+    { id: "tx-002", organizationId: org.id, fundId: generalFund.id, contributorId: bob.id,     type: TransactionType.DONATION,    date: d(10, 15), amount: 1500,  description: "Fall donation" },
+    { id: "tx-003", organizationId: org.id, fundId: generalFund.id, contributorId: carol.id,   type: TransactionType.DONATION,    date: d(9, 8),   amount: 3000,  description: "Major gift" },
+    { id: "tx-004", organizationId: org.id, fundId: generalFund.id, contributorId: sarah.id,   type: TransactionType.DONATION,    date: d(8, 20),  amount: 4500,  description: "Sarah Clay scholarship gift" },
+    { id: "tx-005", organizationId: org.id, fundId: generalFund.id, contributorId: alice.id,   type: TransactionType.EXPENSE,     date: d(7, 20),  amount: 800,   description: "Scholarship disbursement Q1" },
+    { id: "tx-006", organizationId: org.id, fundId: generalFund.id, contributorId: bob.id,     type: TransactionType.WITHDRAWAL,  date: d(6, 10),  amount: 500,   description: "Program operating costs" },
+    { id: "tx-007", organizationId: org.id, fundId: generalFund.id, contributorId: carol.id,   type: TransactionType.DONATION,    date: d(5, 5),   amount: 2200,  description: "Spring gift" },
+    { id: "tx-008", organizationId: org.id, fundId: generalFund.id, contributorId: sarah.id,   type: TransactionType.DONATION,    date: d(4, 12),  amount: 3800,  description: "Q3 contribution" },
+    { id: "tx-009", organizationId: org.id, fundId: generalFund.id, contributorId: alice.id,   type: TransactionType.DONATION,    date: d(3, 7),   amount: 1800,  description: "End of year gift" },
+    { id: "tx-010", organizationId: org.id, fundId: generalFund.id, contributorId: bob.id,     type: TransactionType.DONATION,    date: d(2, 18),  amount: 2600,  description: "Spring contribution" },
+    { id: "tx-011", organizationId: org.id, fundId: generalFund.id, contributorId: carol.id,   type: TransactionType.DONATION,    date: d(1, 9),   amount: 1400,  description: "Monthly giving" },
+    { id: "tx-012", organizationId: org.id, fundId: generalFund.id, contributorId: sarah.id,   type: TransactionType.DONATION,    date: d(0, 4),   amount: 5200,  description: "This month donation" },
 
-  // Tech Fund transactions
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: techFund.id, contributorId: bob.id, type: TransactionType.DONATION, date: d(5, 1), amount: 1200, description: "Tech infrastructure donation" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: techFund.id, contributorId: carol.id, type: TransactionType.DONATION, date: d(4, 12), amount: 800, description: "Software licensing support" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: techFund.id, contributorId: david.id, type: TransactionType.DONATION, date: d(3, 25), amount: 2500, description: "Hardware grant" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: techFund.id, contributorId: bob.id, type: TransactionType.EXPENSE, date: d(2, 7), amount: 600, description: "Server costs Q2" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: techFund.id, contributorId: carol.id, type: TransactionType.EXPENSE, date: d(0, 14), amount: 400, description: "Software subscriptions" } });
+    // --- Endowment Growth Fund ---
+    { id: "tx-013", organizationId: org.id, fundId: endowmentFund.id, contributorId: alice.id,  type: TransactionType.DONATION,   date: d(11, 10), amount: 5000,  description: "Founding endowment gift" },
+    { id: "tx-014", organizationId: org.id, fundId: endowmentFund.id, contributorId: david.id,  type: TransactionType.DONATION,   date: d(10, 2),  amount: 10000, description: "Major endowment contribution" },
+    { id: "tx-015", organizationId: org.id, fundId: endowmentFund.id, contributorId: sarah.id,  type: TransactionType.DONATION,   date: d(9, 5),   amount: 8000,  description: "Endowment pledge" },
+    { id: "tx-016", organizationId: org.id, fundId: endowmentFund.id, contributorId: alice.id,  type: TransactionType.INVESTMENT, date: d(8, 18),  amount: 3000,  description: "Q1 investment allocation" },
+    { id: "tx-017", organizationId: org.id, fundId: endowmentFund.id, contributorId: david.id,  type: TransactionType.INVESTMENT, date: d(6, 22),  amount: 2000,  description: "Reinvestment of returns" },
+    { id: "tx-018", organizationId: org.id, fundId: endowmentFund.id, contributorId: sarah.id,  type: TransactionType.DONATION,   date: d(4, 14),  amount: 6500,  description: "Mid-year endowment gift" },
+    { id: "tx-019", organizationId: org.id, fundId: endowmentFund.id, contributorId: alice.id,  type: TransactionType.INVESTMENT, date: d(2, 3),   amount: 4000,  description: "Q3 investment" },
+    { id: "tx-020", organizationId: org.id, fundId: endowmentFund.id, contributorId: david.id,  type: TransactionType.DONATION,   date: d(0, 8),   amount: 3500,  description: "This month endowment gift" },
 
-  // Research Fund transactions
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: researchFund.id, contributorId: carol.id, type: TransactionType.DONATION, date: d(5, 20), amount: 4000, description: "Research endowment seed gift" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: researchFund.id, contributorId: david.id, type: TransactionType.DONATION, date: d(4, 8), amount: 6000, description: "Faculty research grant" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: researchFund.id, contributorId: carol.id, type: TransactionType.INVESTMENT, date: d(2, 14), amount: 1500, description: "Endowment investment" } });
-  await prisma.transaction.create({ data: { organizationId: org.id, fundId: researchFund.id, contributorId: david.id, type: TransactionType.WITHDRAWAL, date: d(1, 3), amount: 700, description: "Student stipend disbursement" } });
+    // --- Technology Initiative Fund ---
+    { id: "tx-021", organizationId: org.id, fundId: techFund.id, contributorId: bob.id,    type: TransactionType.DONATION,   date: d(11, 1),  amount: 1200,  description: "Tech infrastructure donation" },
+    { id: "tx-022", organizationId: org.id, fundId: techFund.id, contributorId: carol.id,  type: TransactionType.DONATION,   date: d(10, 12), amount: 800,   description: "Software licensing support" },
+    { id: "tx-023", organizationId: org.id, fundId: techFund.id, contributorId: david.id,  type: TransactionType.DONATION,   date: d(9, 25),  amount: 2500,  description: "Hardware grant" },
+    { id: "tx-024", organizationId: org.id, fundId: techFund.id, contributorId: bob.id,    type: TransactionType.DONATION,   date: d(8, 6),   amount: 1900,  description: "Network upgrade fund" },
+    { id: "tx-025", organizationId: org.id, fundId: techFund.id, contributorId: carol.id,  type: TransactionType.EXPENSE,    date: d(7, 7),   amount: 600,   description: "Server costs Q2" },
+    { id: "tx-026", organizationId: org.id, fundId: techFund.id, contributorId: david.id,  type: TransactionType.DONATION,   date: d(6, 19),  amount: 3100,  description: "Innovation gift" },
+    { id: "tx-027", organizationId: org.id, fundId: techFund.id, contributorId: bob.id,    type: TransactionType.DONATION,   date: d(5, 22),  amount: 2200,  description: "Lab equipment gift" },
+    { id: "tx-028", organizationId: org.id, fundId: techFund.id, contributorId: carol.id,  type: TransactionType.DONATION,   date: d(3, 11),  amount: 1700,  description: "Fall tech gift" },
+    { id: "tx-029", organizationId: org.id, fundId: techFund.id, contributorId: david.id,  type: TransactionType.EXPENSE,    date: d(1, 14),  amount: 400,   description: "Software subscriptions" },
+    { id: "tx-030", organizationId: org.id, fundId: techFund.id, contributorId: bob.id,    type: TransactionType.DONATION,   date: d(0, 11),  amount: 2800,  description: "This month tech donation" },
+
+    // --- Research Endowment ---
+    { id: "tx-031", organizationId: org.id, fundId: researchFund.id, contributorId: carol.id,  type: TransactionType.DONATION,   date: d(11, 20), amount: 4000,  description: "Research endowment seed gift" },
+    { id: "tx-032", organizationId: org.id, fundId: researchFund.id, contributorId: david.id,  type: TransactionType.DONATION,   date: d(10, 8),  amount: 6000,  description: "Faculty research grant" },
+    { id: "tx-033", organizationId: org.id, fundId: researchFund.id, contributorId: sarah.id,  type: TransactionType.DONATION,   date: d(9, 15),  amount: 7500,  description: "Research pledge" },
+    { id: "tx-034", organizationId: org.id, fundId: researchFund.id, contributorId: carol.id,  type: TransactionType.INVESTMENT, date: d(7, 14),  amount: 1500,  description: "Endowment investment Q2" },
+    { id: "tx-035", organizationId: org.id, fundId: researchFund.id, contributorId: david.id,  type: TransactionType.WITHDRAWAL, date: d(6, 3),   amount: 700,   description: "Student stipend disbursement" },
+    { id: "tx-036", organizationId: org.id, fundId: researchFund.id, contributorId: sarah.id,  type: TransactionType.DONATION,   date: d(5, 18),  amount: 5000,  description: "Mid-year research gift" },
+    { id: "tx-037", organizationId: org.id, fundId: researchFund.id, contributorId: carol.id,  type: TransactionType.DONATION,   date: d(3, 23),  amount: 3200,  description: "Student research fund" },
+    { id: "tx-038", organizationId: org.id, fundId: researchFund.id, contributorId: david.id,  type: TransactionType.INVESTMENT, date: d(2, 9),   amount: 2500,  description: "Q3 endowment investment" },
+    { id: "tx-039", organizationId: org.id, fundId: researchFund.id, contributorId: sarah.id,  type: TransactionType.DONATION,   date: d(1, 26),  amount: 4800,  description: "Pre-semester gift" },
+    { id: "tx-040", organizationId: org.id, fundId: researchFund.id, contributorId: carol.id,  type: TransactionType.DONATION,   date: d(0, 16),  amount: 3600,  description: "This month research gift" },
+
+    // --- 2 years ago ---
+    { id: "tx-041", organizationId: org.id, fundId: generalFund.id,    contributorId: alice.id,  type: TransactionType.DONATION,    date: y(2, 1, 10), amount: 3000,  description: "New year scholarship gift" },
+    { id: "tx-042", organizationId: org.id, fundId: generalFund.id,    contributorId: bob.id,    type: TransactionType.DONATION,    date: y(2, 3, 5),  amount: 1800,  description: "Spring scholarship" },
+    { id: "tx-043", organizationId: org.id, fundId: generalFund.id,    contributorId: carol.id,  type: TransactionType.EXPENSE,     date: y(2, 5, 14), amount: 700,   description: "Program disbursement" },
+    { id: "tx-044", organizationId: org.id, fundId: generalFund.id,    contributorId: sarah.id,  type: TransactionType.DONATION,    date: y(2, 7, 22), amount: 4200,  description: "Summer gift" },
+    { id: "tx-045", organizationId: org.id, fundId: generalFund.id,    contributorId: alice.id,  type: TransactionType.WITHDRAWAL,  date: y(2, 9, 8),  amount: 600,   description: "Operating withdrawal" },
+    { id: "tx-046", organizationId: org.id, fundId: generalFund.id,    contributorId: bob.id,    type: TransactionType.DONATION,    date: y(2, 11, 3), amount: 2100,  description: "Year-end giving" },
+
+    { id: "tx-047", organizationId: org.id, fundId: endowmentFund.id,  contributorId: david.id,  type: TransactionType.DONATION,    date: y(2, 2, 18), amount: 7000,  description: "Endowment gift Q1" },
+    { id: "tx-048", organizationId: org.id, fundId: endowmentFund.id,  contributorId: alice.id,  type: TransactionType.INVESTMENT,  date: y(2, 6, 12), amount: 3500,  description: "Mid-year investment" },
+    { id: "tx-049", organizationId: org.id, fundId: endowmentFund.id,  contributorId: sarah.id,  type: TransactionType.DONATION,    date: y(2, 10, 1), amount: 9000,  description: "Fall endowment pledge" },
+
+    { id: "tx-050", organizationId: org.id, fundId: techFund.id,       contributorId: carol.id,  type: TransactionType.DONATION,    date: y(2, 2, 7),  amount: 1500,  description: "Tech seed gift" },
+    { id: "tx-051", organizationId: org.id, fundId: techFund.id,       contributorId: david.id,  type: TransactionType.DONATION,    date: y(2, 6, 20), amount: 2800,  description: "Infrastructure support" },
+    { id: "tx-052", organizationId: org.id, fundId: techFund.id,       contributorId: bob.id,    type: TransactionType.EXPENSE,     date: y(2, 9, 15), amount: 900,   description: "Equipment costs" },
+
+    { id: "tx-053", organizationId: org.id, fundId: researchFund.id,   contributorId: sarah.id,  type: TransactionType.DONATION,    date: y(2, 3, 25), amount: 5500,  description: "Research pledge" },
+    { id: "tx-054", organizationId: org.id, fundId: researchFund.id,   contributorId: david.id,  type: TransactionType.INVESTMENT,  date: y(2, 7, 9),  amount: 2000,  description: "Endowment investment" },
+    { id: "tx-055", organizationId: org.id, fundId: researchFund.id,   contributorId: carol.id,  type: TransactionType.DONATION,    date: y(2, 11, 18),amount: 4100,  description: "Year-end research gift" },
+
+    // --- 3 years ago ---
+    { id: "tx-056", organizationId: org.id, fundId: generalFund.id,    contributorId: sarah.id,  type: TransactionType.DONATION,    date: y(3, 2, 14), amount: 2500,  description: "Early scholarship gift" },
+    { id: "tx-057", organizationId: org.id, fundId: generalFund.id,    contributorId: alice.id,  type: TransactionType.DONATION,    date: y(3, 6, 3),  amount: 1600,  description: "Summer contribution" },
+    { id: "tx-058", organizationId: org.id, fundId: generalFund.id,    contributorId: bob.id,    type: TransactionType.DONATION,    date: y(3, 10, 19),amount: 3300,  description: "Fall donation" },
+
+    { id: "tx-059", organizationId: org.id, fundId: endowmentFund.id,  contributorId: david.id,  type: TransactionType.DONATION,    date: y(3, 1, 22), amount: 12000, description: "Founding endowment gift" },
+    { id: "tx-060", organizationId: org.id, fundId: endowmentFund.id,  contributorId: sarah.id,  type: TransactionType.INVESTMENT,  date: y(3, 5, 7),  amount: 4500,  description: "Initial investment" },
+    { id: "tx-061", organizationId: org.id, fundId: endowmentFund.id,  contributorId: alice.id,  type: TransactionType.WITHDRAWAL,  date: y(3, 8, 11), amount: 1000,  description: "Annual distribution" },
+
+    { id: "tx-062", organizationId: org.id, fundId: techFund.id,       contributorId: bob.id,    type: TransactionType.DONATION,    date: y(3, 4, 2),  amount: 2000,  description: "Tech launch gift" },
+    { id: "tx-063", organizationId: org.id, fundId: techFund.id,       contributorId: carol.id,  type: TransactionType.DONATION,    date: y(3, 9, 28), amount: 3500,  description: "Infrastructure grant" },
+
+    { id: "tx-064", organizationId: org.id, fundId: researchFund.id,   contributorId: carol.id,  type: TransactionType.DONATION,    date: y(3, 3, 17), amount: 6000,  description: "Research endowment founding" },
+    { id: "tx-065", organizationId: org.id, fundId: researchFund.id,   contributorId: david.id,  type: TransactionType.DONATION,    date: y(3, 8, 6),  amount: 4500,  description: "Faculty research gift" },
+  ];
+
+  for (const tx of transactions) {
+    await prisma.transaction.upsert({
+      where: { id: tx.id },
+      update: {},
+      create: tx,
+    });
+  }
 
   // Update fund balances
-  await prisma.fund.update({ where: { id: generalFund.id }, data: { amount: 6200 } });
-  await prisma.fund.update({ where: { id: endowmentFund.id }, data: { amount: 20000, units: 400 } });
-  await prisma.fund.update({ where: { id: techFund.id }, data: { amount: 3500 } });
-  await prisma.fund.update({ where: { id: researchFund.id }, data: { amount: 10800, units: 270 } });
+  await prisma.fund.update({ where: { id: generalFund.id }, data: { amount: 27700 } });
+  await prisma.fund.update({ where: { id: endowmentFund.id }, data: { amount: 42000, units: 840 } });
+  await prisma.fund.update({ where: { id: techFund.id }, data: { amount: 15700 } });
+  await prisma.fund.update({ where: { id: researchFund.id }, data: { amount: 37400, units: 935 } });
 
   // Update org total
-  await prisma.organization.update({ where: { id: org.id }, data: { amount: 40500 } });
+  await prisma.organization.update({ where: { id: org.id }, data: { amount: 122800 } });
 
-  console.log("Seed complete: Carl's Test Foundation with 4 contributors, 4 funds, 19 transactions");
+  console.log("Seed complete: 5 contributors, 4 funds, 40 transactions across 12 months");
 }
 
 main()

--- a/backend/src/controllers/transactions.ts
+++ b/backend/src/controllers/transactions.ts
@@ -240,12 +240,13 @@ const createTransaction = async (
       },
     });
 
-    // Update the fund's amount and units
+    // Update the fund's amount and units, and link contributor to fund
     await prisma.fund.update({
       where: { id: transactionData.fundId },
       data: {
         amount: amountUpdate,
         units: unitsUpdate,
+        contributors: { connect: { id: transactionData.contributorId } },
       },
     });
 

--- a/backend/src/controllers/transactions.ts
+++ b/backend/src/controllers/transactions.ts
@@ -452,7 +452,7 @@ async function getContributorTransactions(
 
   if (filters.organizationId) {
     where.organizationId = filters.organizationId;
-    const organization = await prisma.contributor.findUnique({
+    const organization = await prisma.organization.findUnique({
       where: { id: filters.organizationId },
       select: { id: true },
     });

--- a/backend/src/utils/api-spec.json
+++ b/backend/src/utils/api-spec.json
@@ -258,29 +258,15 @@
       },
       "post": {
         "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "firstName": {
-                  "example": "any"
-                },
-                "lastName": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
         "responses": {
           "201": {
             "description": "Created"
           },
           "400": {
             "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -300,6 +286,12 @@
           "200": {
             "description": "OK"
           },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
           "404": {
             "description": "Not Found"
           },
@@ -316,11 +308,32 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "where": {
+                  "example": "any"
+                },
+                "select": {
+                  "example": "any"
+                }
+              }
+            }
           }
         ],
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           },
           "404": {
             "description": "Not Found"
@@ -343,6 +356,15 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }
@@ -361,6 +383,15 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
           },
           "500": {
             "description": "Internal Server Error"
@@ -690,41 +721,15 @@
       },
       "post": {
         "description": "",
-        "parameters": [
-          {
-            "name": "body",
-            "in": "body",
-            "schema": {
-              "type": "object",
-              "properties": {
-                "organizationId": {
-                  "example": "any"
-                },
-                "contributorId": {
-                  "example": "any"
-                },
-                "fundId": {
-                  "example": "any"
-                },
-                "type": {
-                  "example": "any"
-                },
-                "date": {
-                  "example": "any"
-                },
-                "amount": {
-                  "example": "any"
-                }
-              }
-            }
-          }
-        ],
         "responses": {
           "201": {
             "description": "Created"
           },
           "400": {
             "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
           }
         }
       }
@@ -744,6 +749,12 @@
           "200": {
             "description": "OK"
           },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
           "404": {
             "description": "Not Found"
           },
@@ -760,6 +771,21 @@
             "in": "path",
             "required": true,
             "type": "string"
+          },
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "where": {
+                  "example": "any"
+                },
+                "select": {
+                  "example": "any"
+                }
+              }
+            }
           }
         ],
         "responses": {
@@ -768,6 +794,15 @@
           },
           "400": {
             "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       },
@@ -785,8 +820,53 @@
           "200": {
             "description": "OK"
           },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
           "404": {
             "description": "Not Found"
+          }
+        }
+      }
+    },
+    "/transactions/bulk": {
+      "post": {
+        "description": "",
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "schema": {
+              "type": "object",
+              "properties": {
+                "where": {
+                  "example": "any"
+                },
+                "select": {
+                  "example": "any"
+                }
+              }
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Created"
+          },
+          "207": {
+            "description": "Multi-Status"
+          },
+          "400": {
+            "description": "Bad Request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "500": {
+            "description": "Internal Server Error"
           }
         }
       }
@@ -845,6 +925,12 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
           }
         }
       }
@@ -861,11 +947,6 @@
           },
           {
             "name": "type",
-            "in": "query",
-            "type": "string"
-          },
-          {
-            "name": "organizationId",
             "in": "query",
             "type": "string"
           },
@@ -903,6 +984,15 @@
         "responses": {
           "200": {
             "description": "OK"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Forbidden"
+          },
+          "404": {
+            "description": "Not Found"
           }
         }
       }

--- a/frontend/src/app/activity/page.tsx
+++ b/frontend/src/app/activity/page.tsx
@@ -3,89 +3,200 @@
 export const dynamic = "force-dynamic";
 
 import { Suspense, useRef, useState, useEffect } from "react";
+import { createPortal } from "react-dom";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
-import TransactionsTable from "@/components/molecules/TransactionsTable";
+import TransactionsTable, { TransactionFilterType, TransactionSortBy } from "@/components/molecules/TransactionsTable";
 import SearchBar from "@/components/molecules/Searchbar";
-import AddIcon from "@mui/icons-material/Add";
-import DownloadIcon from "@mui/icons-material/Download";
 import Button from "@/components/atoms/Button";
+import FilterAltIcon from "@mui/icons-material/FilterAlt";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
+import { Plus, ArrowUpRight } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
+
+const buttonColor = "#838383";
+
+function useDropdown() {
+  const [open, setOpen] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
+  const toggle = () => {
+    if (!open && buttonRef.current) setRect(buttonRef.current.getBoundingClientRect());
+    setOpen((o) => !o);
+  };
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+  return { open, setOpen, toggle, rect, buttonRef };
+}
 
 function ActivitiesContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [searchQuery, setSearchQuery] = useState("");
   const [refreshKey, setRefreshKey] = useState(0);
+  const [filterType, setFilterType] = useState<TransactionFilterType>("all");
+  const [sortBy, setSortBy] = useState<TransactionSortBy>("date-desc");
+
+  const filterDropdown = useDropdown();
+  const sortDropdown = useDropdown();
 
   useEffect(() => {
     setRefreshKey((k) => k + 1);
   }, [searchParams]);
 
-  const [dropdownOpen, setDropdownOpen] = useState(false);
-  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [addOpen, setAddOpen] = useState(false);
+  const addRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handler = (e: MouseEvent) => {
-      if (dropdownRef.current && !dropdownRef.current.contains(e.target as Node)) {
-        setDropdownOpen(false);
-      }
+      if (addRef.current && !addRef.current.contains(e.target as Node)) setAddOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, []);
 
+  const filterActive = filterType !== "all";
+
   return (
     <DashboardTemplate>
       <div className="flex flex-col justify-items-center">
-        <h1 className="mb-12 text-3xl">Activity</h1>
-        <div className="mb-12 flex items-center justify-center gap-x-4">
+        <h1 className="mb-12 text-3xl font-bold">Activity</h1>
+        <div className="mb-6 flex items-center gap-x-4">
           <div className="flex-grow">
-            <SearchBar onSearch={setSearchQuery} width="50%" />
+            <SearchBar onSearch={setSearchQuery} width="100%" />
+          </div>
+
+          {/* Filter button */}
+          <div ref={filterDropdown.buttonRef}>
+            <Button
+              variant="secondary"
+              onClick={filterDropdown.toggle}
+              style={{
+                display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 0,
+                color: filterActive ? "#3E6DA6" : buttonColor,
+                fontWeight: filterActive ? 600 : undefined,
+              }}
+            >
+              <FilterAltIcon style={{ marginRight: "6px" }} />
+              Filter{filterActive ? " •" : ""}
+            </Button>
+          </div>
+
+          {/* Sort button */}
+          <div ref={sortDropdown.buttonRef}>
+            <Button
+              variant="secondary"
+              onClick={sortDropdown.toggle}
+              style={{ display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 0, color: buttonColor }}
+            >
+              <SwapVertIcon />
+              Sort
+              <KeyboardArrowDownIcon />
+            </Button>
           </div>
 
           {/* Add Transaction dropdown */}
-          <div className="relative" ref={dropdownRef}>
-            <Button
-              variant="primary"
-              style={{ display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 8 }}
-              onClick={() => setDropdownOpen((prev) => !prev)}
+          <div className="relative" ref={addRef}>
+            <button
+              onClick={() => setAddOpen((prev) => !prev)}
+              className="inline-flex items-center gap-2 rounded-lg bg-[#3E6DA6] px-4 py-2 text-sm font-medium"
+              style={{ backgroundColor: "#3E6DA6", color: "white" }}
             >
-              <AddIcon style={{ marginRight: "6px" }} />
+              <Plus size={16} />
               Add Transaction
-            </Button>
-
-            {dropdownOpen && (
-              <div className="bg-white absolute right-0 top-full mt-1 z-50 min-w-[160px] overflow-hidden rounded-lg border border-gray-200 shadow-lg">
-                <button
-                  className="hover:bg-gray-50 w-full px-4 py-3 text-left text-sm"
-                  onClick={() => { setDropdownOpen(false); router.push("/activity/add-multiple"); }}
-                >
-                  Add Manually
-                </button>
-                <button
-                  className="hover:bg-gray-50 w-full px-4 py-3 text-left text-sm"
-                  onClick={() => { setDropdownOpen(false); router.push("/activity/add-csv"); }}
-                >
-                  Import by CSV
-                </button>
+            </button>
+            {addOpen && (
+              <div className="absolute right-0 top-full mt-1 z-50 min-w-[160px] overflow-hidden rounded-lg border border-gray-200 bg-white shadow-lg">
+                <button className="w-full px-4 py-3 text-left text-sm hover:bg-gray-50" onClick={() => { setAddOpen(false); router.push("/activity/add-multiple"); }}>Add Manually</button>
+                <button className="w-full px-4 py-3 text-left text-sm hover:bg-gray-50" onClick={() => { setAddOpen(false); router.push("/activity/add-csv"); }}>Import by CSV</button>
               </div>
             )}
           </div>
 
-          <Button
-            variant="primary"
-            icon={<DownloadIcon />}
-            style={{ display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 8 }}
+          <button
+            className="inline-flex items-center gap-2 rounded-lg border border-[#3E6DA6] bg-white px-4 py-2 text-sm font-medium text-[#3E6DA6] hover:bg-[#3E6DA6]/5"
           >
+            <ArrowUpRight size={16} />
             Export
-          </Button>
+          </button>
         </div>
+
         <TransactionsTable
           tableType="transactions"
           searchQuery={searchQuery}
+          filterType={filterType}
+          sortBy={sortBy}
           key={refreshKey}
         />
       </div>
+
+      {/* Filter portal */}
+      {filterDropdown.open && filterDropdown.rect && createPortal(
+        <div
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            position: "fixed",
+            top: filterDropdown.rect.bottom + 8,
+            left: filterDropdown.rect.right - 200,
+            zIndex: 9999,
+            backgroundColor: "white",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+          }}
+          className="min-w-[200px] rounded-lg p-4"
+        >
+          <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Type</p>
+          {(["all", "DONATION", "INVESTMENT", "WITHDRAWAL", "EXPENSE"] as TransactionFilterType[]).map((v) => (
+            <label key={v} className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+              <input type="radio" name="activityFilterType" checked={filterType === v} onChange={() => setFilterType(v)} />
+              {v === "all" ? "All types" : v.charAt(0) + v.slice(1).toLowerCase()}
+            </label>
+          ))}
+          {filterActive && (
+            <button className="mt-3 text-xs text-blue-500 underline" onClick={() => setFilterType("all")}>
+              Clear filter
+            </button>
+          )}
+        </div>,
+        document.body
+      )}
+
+      {/* Sort portal */}
+      {sortDropdown.open && sortDropdown.rect && createPortal(
+        <div
+          onMouseDown={(e) => e.stopPropagation()}
+          style={{
+            position: "fixed",
+            top: sortDropdown.rect.bottom + 8,
+            left: sortDropdown.rect.right - 180,
+            zIndex: 9999,
+            backgroundColor: "white",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+          }}
+          className="min-w-[180px] rounded-lg p-4"
+        >
+          <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Sort by</p>
+          {([
+            ["date-desc", "Date: newest first"],
+            ["date-asc", "Date: oldest first"],
+            ["amount-desc", "Amount: high to low"],
+            ["amount-asc", "Amount: low to high"],
+            ["contributor-asc", "Contributor A → Z"],
+            ["contributor-desc", "Contributor Z → A"],
+          ] as [TransactionSortBy, string][]).map(([value, label]) => (
+            <label key={value} className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+              <input type="radio" name="activitySort" checked={sortBy === value} onChange={() => { setSortBy(value); sortDropdown.setOpen(false); }} />
+              {label}
+            </label>
+          ))}
+        </div>,
+        document.body
+      )}
     </DashboardTemplate>
   );
 }

--- a/frontend/src/app/contributors/[id]/page.tsx
+++ b/frontend/src/app/contributors/[id]/page.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+export const dynamic = "force-dynamic";
+
+import { use, useEffect, useState, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import DashboardTemplate from "@/components/templates/DashboardTemplate";
+import { SimpleTable, Column } from "@/components/molecules/SimpleTable";
+import api from "@/utils/api";
+import {
+  LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer,
+} from "recharts";
+import LaunchIcon from "@mui/icons-material/Launch";
+
+interface Transaction {
+  id: string;
+  type: "DONATION" | "WITHDRAWAL" | "INVESTMENT" | "EXPENSE";
+  date: string;
+  amount: number;
+  units?: number;
+  fund?: { id: string; name: string };
+  fundId?: string;
+}
+
+interface ContributorDetail {
+  id: string;
+  firstName: string;
+  lastName: string;
+  funds: { id: string; name: string }[];
+}
+
+interface TableRow {
+  id: string;
+  date: string;
+  contributor: string;
+  fund: string;
+  amount: number;
+}
+
+const fmt = (n: number) =>
+  new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(n);
+
+export default function ContributorDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = use(params);
+  const router = useRouter();
+
+  const [contributor, setContributor] = useState<ContributorDetail | null>(null);
+  const [transactions, setTransactions] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        const [cRes, tRes] = await Promise.all([
+          api.get(`/contributors/${id}`),
+          api.get(`/transactions/contributors/${id}`),
+        ]);
+        setContributor(cRes.data);
+        setTransactions(tRes.data.transactions ?? []);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load");
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, [id]);
+
+  const donations = useMemo(
+    () => transactions.filter((t) => t.type === "DONATION" || t.type === "INVESTMENT"),
+    [transactions]
+  );
+
+  const oneYearAgo = useMemo(() => {
+    const d = new Date();
+    d.setFullYear(d.getFullYear() - 1);
+    return d;
+  }, []);
+
+  const oneYearDonations = useMemo(
+    () => donations.filter((t) => new Date(t.date) >= oneYearAgo),
+    [donations, oneYearAgo]
+  );
+
+  const oneYearEarnings = useMemo(
+    () => oneYearDonations.reduce((s, t) => s + t.amount, 0),
+    [oneYearDonations]
+  );
+
+  const totalContributions = useMemo(
+    () => donations.reduce((s, t) => s + t.amount, 0),
+    [donations]
+  );
+
+  const startBalance = totalContributions - oneYearEarnings;
+  const base = startBalance > 0 ? startBalance : (totalContributions > 0 ? totalContributions : null);
+  const oneYearReturn = base !== null && oneYearEarnings !== 0 ? (oneYearEarnings / base) * 100 : null;
+
+  // Build monthly chart data for the last 12 months
+  const chartData = useMemo(() => {
+    const months: Record<string, number> = {};
+    const now = new Date();
+    for (let i = 11; i >= 0; i--) {
+      const d = new Date(now.getFullYear(), now.getMonth() - i, 1);
+      const key = d.toLocaleDateString("en-US", { month: "short" });
+      months[key] = 0;
+    }
+    oneYearDonations.forEach((t) => {
+      const key = new Date(t.date).toLocaleDateString("en-US", { month: "short" });
+      if (key in months) months[key] += t.amount;
+    });
+    // Convert to cumulative
+    let cum = 0;
+    return Object.entries(months).map(([month, val]) => {
+      cum += val;
+      return { month, amount: cum };
+    });
+  }, [oneYearDonations]);
+
+  const tableRows: TableRow[] = useMemo(
+    () =>
+      [...donations]
+        .sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+        .map((t) => ({
+          id: t.id,
+          date: new Date(t.date).toLocaleDateString(),
+          contributor: contributor
+            ? `${contributor.firstName} ${contributor.lastName}`
+            : "—",
+          fund: t.fund?.name ?? "—",
+          amount: t.amount,
+        })),
+    [donations, contributor]
+  );
+
+  const columns: Column<TableRow>[] = [
+    { header: "Date", accessor: "date", dataType: "date", sortable: true },
+    { header: "Contributor", accessor: "contributor", dataType: "string", sortable: true },
+    { header: "Fund", accessor: "fund", dataType: "string", sortable: true },
+    {
+      header: "Amount",
+      accessor: "amount",
+      dataType: "number",
+      sortable: true,
+      headerClassName: "text-right",
+      className: "text-right font-medium",
+      Cell: (value) => (
+        <span style={{ color: value >= 0 ? "green" : "red" }}>
+          {value >= 0 ? "+" : "-"}{fmt(Math.abs(value))}
+        </span>
+      ),
+    },
+  ];
+
+  if (loading) return <DashboardTemplate><div className="p-8">Loading...</div></DashboardTemplate>;
+  if (error || !contributor) return <DashboardTemplate><div className="p-8 text-red-500">{error ?? "Not found"}</div></DashboardTemplate>;
+
+  const name = `${contributor.firstName} ${contributor.lastName}`;
+
+  return (
+    <DashboardTemplate>
+      <div className="space-y-8">
+
+        {/* Breadcrumb */}
+        <div className="flex items-center gap-2 text-sm text-gray-400">
+          <button onClick={() => router.push("/contributors")} className="hover:text-gray-600">
+            Contributors
+          </button>
+          <span>›</span>
+          <span className="text-gray-600">{name}</span>
+        </div>
+
+        {/* Name row */}
+        <div className="flex items-center justify-between">
+          <h1 className="text-3xl font-bold">{name}</h1>
+          <button className="text-gray-400 hover:text-gray-600 text-xl">⋯</button>
+        </div>
+
+
+        {/* Total Contributions section */}
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-xl font-bold">{contributor.firstName}'s Total Contributions</h2>
+            <button className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-1.5 text-sm text-gray-600 hover:bg-gray-50">
+              Export <LaunchIcon fontSize="small" />
+            </button>
+          </div>
+
+          <div className="flex gap-4">
+            {/* Chart card */}
+            <div className="flex-1 rounded-xl border bg-white p-5 shadow-sm">
+              <div className="mb-1 text-sm text-gray-500">Yearly Contributions</div>
+              <div className="mb-4 text-2xl font-bold">{fmt(totalContributions)}</div>
+              <ResponsiveContainer width="100%" height={260}>
+                <LineChart data={chartData} margin={{ left: 8, right: 8, top: 4, bottom: 4 }}>
+                  <CartesianGrid vertical={false} stroke="#f0f0f0" />
+                  <XAxis dataKey="month" axisLine={false} tickLine={false} tick={{ fontSize: 12 }} />
+                  <YAxis
+                    axisLine={false}
+                    tickLine={false}
+                    tick={{ fontSize: 12 }}
+                    tickFormatter={(v) => `${(v / 1000).toFixed(0)}K`}
+                  />
+                  <Tooltip formatter={(v: number) => fmt(v)} />
+                  <Line type="linear" dataKey="amount" stroke="#000" strokeWidth={2} dot={false} />
+                </LineChart>
+              </ResponsiveContainer>
+            </div>
+
+            {/* Stats cards */}
+            <div className="flex w-56 shrink-0 flex-col gap-4">
+              <div className="rounded-xl border bg-white p-5 shadow-sm">
+                <div className={`text-2xl font-bold ${oneYearReturn !== null && oneYearReturn >= 0 ? "text-black" : "text-red-500"}`}>
+                  {oneYearReturn !== null
+                    ? `${oneYearReturn >= 0 ? "+" : ""}${oneYearReturn.toFixed(2)}%`
+                    : "—"}
+                </div>
+                <div className="mt-1 text-sm text-gray-500">1-Year Return</div>
+              </div>
+              <div className="rounded-xl border bg-white p-5 shadow-sm">
+                <div className="text-2xl font-bold">{fmt(oneYearEarnings)}</div>
+                <div className="mt-1 text-sm text-gray-500">1-Year Earnings</div>
+              </div>
+              <div className="rounded-xl border bg-white p-5 shadow-sm">
+                <div className="text-2xl font-bold">{fmt(totalContributions)}</div>
+                <div className="mt-1 text-sm text-gray-500">1-Year Contributions</div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Contribution History */}
+        <div>
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-xl font-bold">{contributor.firstName}'s Contribution History</h2>
+            <button className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-1.5 text-sm text-gray-600 hover:bg-gray-50">
+              Export <LaunchIcon fontSize="small" />
+            </button>
+          </div>
+          <SimpleTable<TableRow>
+            data={tableRows}
+            columns={columns}
+            pageSize={6}
+          />
+        </div>
+
+      </div>
+    </DashboardTemplate>
+  );
+}

--- a/frontend/src/app/contributors/page.tsx
+++ b/frontend/src/app/contributors/page.tsx
@@ -2,69 +2,377 @@
 
 export const dynamic = "force-dynamic";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
+import { createPortal } from "react-dom";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import ContributorsTable from "@/components/molecules/ContributorsTable";
-import AddIcon from "@mui/icons-material/Add";
-import LaunchIcon from "@mui/icons-material/Launch";
-import Button from "@/components/atoms/Button";
 import AddContributorModal from "@/components/molecules/AddContributorModal";
-import SearchBar from "@/components/molecules/Searchbar"; // Import the SearchBar component
+import SearchBar from "@/components/molecules/Searchbar";
+import FilterListIcon from "@mui/icons-material/FilterList";
+import LaunchIcon from "@mui/icons-material/Launch";
+import api from "@/utils/api";
+
+export type ContributorSortBy = "date-desc" | "date-asc" | "name-asc" | "name-desc" | "amount-desc" | "amount-asc";
+
+function useDropdown() {
+  const [open, setOpen] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  const toggle = () => {
+    if (!open && buttonRef.current) setRect(buttonRef.current.getBoundingClientRect());
+    setOpen((o) => !o);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return { open, setOpen, toggle, rect, buttonRef };
+}
+
+// ── Email tab ──────────────────────────────────────────────────────────────
+
+interface ContributorItem {
+  id: string;
+  firstName: string;
+  lastName: string;
+  funds: { id: string; name: string }[];
+  transactions: { amount: number; type: string }[];
+}
+
+const TEMPLATES = [
+  { title: "Contact a contributor", tag: "Donor Relations", tagColor: "bg-yellow-100 text-yellow-700" },
+  { title: "Invite new contributors", tag: "Donor Relations", tagColor: "bg-yellow-100 text-yellow-700" },
+  { title: "Send a report", tag: "Report", tagColor: "bg-blue-100 text-blue-700" },
+  { title: "Thank a contributor", tag: "Donor Relations", tagColor: "bg-yellow-100 text-yellow-700" },
+];
+
+function EmailTab() {
+  const [contributors, setContributors] = useState<ContributorItem[]>([]);
+  const [toQuery, setToQuery] = useState("");
+  const [toOpen, setToOpen] = useState(false);
+  const [selectedContributor, setSelectedContributor] = useState<ContributorItem | null>(null);
+  const [subject, setSubject] = useState("");
+  const [message, setMessage] = useState("");
+  const toRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    api.get("/contributors").then((res) => {
+      setContributors(res.data.contributors ?? []);
+    }).catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!toOpen) return;
+    const handler = (e: MouseEvent) => {
+      if (toRef.current && !toRef.current.contains(e.target as Node)) setToOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [toOpen]);
+
+  const topContributors = [...contributors]
+    .map((c) => ({
+      ...c,
+      total: c.transactions
+        .filter((t) => t.type === "DONATION" || t.type === "INVESTMENT")
+        .reduce((s, t) => s + t.amount, 0),
+      fund: c.funds?.[0]?.name ?? "—",
+    }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 6);
+
+  const filteredContributors = contributors.filter((c) =>
+    `${c.firstName} ${c.lastName}`.toLowerCase().includes(toQuery.toLowerCase())
+  );
+
+  const fmtAmt = (n: number) =>
+    new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
+
+  return (
+    <div className="space-y-8">
+      {/* Templates */}
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-xl font-bold text-white">Templates</h2>
+          <button className="flex items-center gap-1 text-sm text-blue-300 hover:underline">
+            See more →
+          </button>
+        </div>
+        <div className="grid grid-cols-4 gap-4">
+          {TEMPLATES.map((t) => (
+            <button
+              key={t.title}
+              className="flex h-36 flex-col justify-between rounded-xl border border-gray-200 bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md"
+            >
+              <p className="text-sm font-semibold leading-snug">{t.title}</p>
+              <span className={`w-fit rounded px-2 py-0.5 text-xs font-medium ${t.tagColor}`}>{t.tag}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Send an Email */}
+      <div>
+        <h2 className="mb-4 text-xl font-bold text-white">Send an Email</h2>
+        <div className="flex gap-4 items-start">
+
+          {/* Left: top contributors */}
+          <div className="w-72 shrink-0 rounded-xl border border-gray-200 bg-white shadow-sm">
+            {/* Header */}
+            <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
+              <span className="text-sm font-medium text-gray-800">Last Month's Top Contributors</span>
+              <FilterListIcon fontSize="small" style={{ color: "#3E6DA6" }} />
+            </div>
+            {/* Rows */}
+            <div className="divide-y divide-gray-50 px-4">
+              {topContributors.length === 0 ? (
+                <p className="py-4 text-xs text-gray-400">No contributors yet</p>
+              ) : (
+                topContributors.map((c) => (
+                  <div key={c.id} className="flex items-center justify-between py-3">
+                    <div>
+                      <p className="text-sm font-semibold text-gray-900">{c.firstName} {c.lastName}</p>
+                      <p className="text-xs text-gray-400">{c.fund}</p>
+                    </div>
+                    <span className="text-sm font-medium text-green-600">+{fmtAmt(c.total)}</span>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+
+          {/* Right: compose */}
+          <div className="flex-1 rounded-xl border border-gray-200 bg-white shadow-sm">
+            {/* Compose header */}
+            <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
+              <h3 className="font-semibold text-gray-900">New Email</h3>
+              <button className="text-lg text-gray-400 hover:text-gray-600">↗</button>
+            </div>
+
+            <div className="px-6 py-5 space-y-5">
+              {/* To */}
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold text-gray-800">To</label>
+                <div className="relative" ref={toRef}>
+                  <div
+                    className="flex cursor-text items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2.5"
+                    onClick={() => setToOpen(true)}
+                  >
+                    {selectedContributor ? (
+                      <span className="text-sm text-gray-800">{selectedContributor.firstName} {selectedContributor.lastName}</span>
+                    ) : (
+                      <input
+                        type="text"
+                        placeholder="Type a contributor"
+                        value={toQuery}
+                        onChange={(e) => { setToQuery(e.target.value); setToOpen(true); }}
+                        className="w-full bg-transparent text-sm text-gray-500 outline-none placeholder:text-gray-400"
+                      />
+                    )}
+                    <svg className="h-4 w-4 shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+                    </svg>
+                  </div>
+                  {toOpen && (
+                    <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg">
+                      {filteredContributors.length === 0 ? (
+                        <p className="px-3 py-2 text-sm text-gray-400">No contributors found</p>
+                      ) : (
+                        filteredContributors.slice(0, 8).map((c) => (
+                          <button
+                            key={c.id}
+                            className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                            onClick={() => { setSelectedContributor(c); setToQuery(""); setToOpen(false); }}
+                          >
+                            {c.firstName} {c.lastName}
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  )}
+                </div>
+                {selectedContributor && (
+                  <button className="mt-1 text-xs text-gray-400 underline" onClick={() => setSelectedContributor(null)}>
+                    Clear
+                  </button>
+                )}
+              </div>
+
+              {/* Subject */}
+              <div>
+                <label className="mb-1.5 block text-sm font-semibold text-gray-800">Subject</label>
+                <input
+                  type="text"
+                  placeholder="Type a subject"
+                  value={subject}
+                  onChange={(e) => setSubject(e.target.value)}
+                  className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-800 outline-none placeholder:text-gray-400 focus:border-gray-400"
+                />
+              </div>
+
+              {/* Message */}
+              <div>
+                <div className="mb-1.5 flex items-center justify-between">
+                  <label className="text-sm font-semibold text-gray-800">Message</label>
+                  <div className="flex items-center gap-3 text-gray-400">
+                    <button title="Attach" className="hover:text-gray-600 text-base">↑</button>
+                    <button title="Link" className="hover:text-gray-600 text-base">🔗</button>
+                    <button title="Image" className="hover:text-gray-600 text-base">🖼</button>
+                    <button title="Bold" className="hover:text-gray-600 text-sm font-bold">B</button>
+                    <button title="Italic" className="hover:text-gray-600 text-sm italic">I</button>
+                    <button title="Bullet list" className="hover:text-gray-600 text-base">☰</button>
+                    <button title="Numbered list" className="hover:text-gray-600 text-base">≣</button>
+                  </div>
+                </div>
+                <textarea
+                  placeholder="Type a message"
+                  value={message}
+                  onChange={(e) => setMessage(e.target.value)}
+                  rows={8}
+                  className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-800 outline-none placeholder:text-gray-400 focus:border-gray-400"
+                />
+              </div>
+            </div>
+
+            {/* Footer */}
+            <div className="flex justify-end gap-3 border-t border-gray-100 px-6 py-4">
+              <button
+                className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+                onClick={() => { setSelectedContributor(null); setSubject(""); setMessage(""); }}
+              >
+                Cancel
+              </button>
+              <button className="rounded-lg bg-gray-700 px-5 py-2 text-sm font-medium text-white hover:bg-gray-800">
+                Send Email
+              </button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Page ───────────────────────────────────────────────────────────────────
 
 const ContributorsPage = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [refreshToken, setRefreshToken] = useState(0);
+  const [activeTab, setActiveTab] = useState<"table" | "email">("table");
+  const [sortBy, setSortBy] = useState<ContributorSortBy>("date-desc");
 
-  const handleSearch = (query: string) => {
-    console.log("Searching for:", query);
-    setSearchQuery(query);
-  };
+  const sortDropdown = useDropdown();
 
   return (
     <DashboardTemplate>
-      <div className="flex flex-col justify-items-center">
-        <h1 className="mb-12 text-3xl">Contributors</h1>
-        <div className="mb-12 flex items-center justify-center gap-x-4">
-          <div className="flex-grow">
-            <SearchBar onSearch={handleSearch} width="50%" />
-          </div>
-
-          <AddContributorModal onAdded={() => setRefreshToken((v) => v + 1)}>
-            <Button
-              variant="primary"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                height: "40px",
-                padding: "0 16px",
-                marginBottom: 8,
-              }}
-            >
-              Add Contributor
-              <AddIcon style={{ marginLeft: "6px" }} />
-            </Button>
-          </AddContributorModal>
-
-          <Button
-            variant="primary"
-            icon={<LaunchIcon />}
-            style={{
-              display: "flex",
-              alignItems: "center",
-              height: "40px",
-              padding: "0 16px",
-              marginBottom: 8,
-            }}
-          >
-            Export
-          </Button>
+      <div className="flex flex-col">
+        {/* Header */}
+        <div className="mb-4 flex items-center justify-between">
+          <h1 className="text-3xl font-bold">Contributors</h1>
+          {activeTab === "email" && (
+            <div className="w-56">
+              <SearchBar onSearch={() => {}} width="100%" placeholder="Search" />
+            </div>
+          )}
         </div>
 
-        <ContributorsTable
-          searchQuery={searchQuery}
-          refreshToken={refreshToken}
-        />
+        {/* Tabs */}
+        <div className="mb-6 flex space-x-6 border-b">
+          {(["table", "email"] as const).map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`pb-3 text-base capitalize transition-colors ${
+                activeTab === tab
+                  ? "border-b-2 border-black font-semibold text-black"
+                  : "text-gray-400 hover:text-gray-600"
+              }`}
+            >
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+            </button>
+          ))}
+        </div>
+
+        {activeTab === "table" && (
+          <>
+            <div className="mb-6 flex items-center gap-x-3">
+              <div className="w-[340px]">
+                <SearchBar onSearch={setSearchQuery} width="100%" />
+              </div>
+              <div className="flex-1" />
+              <AddContributorModal onAdded={() => setRefreshToken((v) => v + 1)}>
+                <button
+                  className="flex items-center gap-1 rounded-md px-4 py-2 text-sm font-medium"
+                  style={{ backgroundColor: "#3E6DA6", color: "white" }}
+                >
+                  Add Contributor +
+                </button>
+              </AddContributorModal>
+              <div ref={sortDropdown.buttonRef}>
+                <button
+                  onClick={sortDropdown.toggle}
+                  className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
+                >
+                  <FilterListIcon fontSize="small" />
+                  Filters
+                </button>
+              </div>
+              <button className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50">
+                Export <LaunchIcon fontSize="small" />
+              </button>
+            </div>
+            <ContributorsTable searchQuery={searchQuery} refreshToken={refreshToken} sortBy={sortBy} />
+          </>
+        )}
+
+        {activeTab === "email" && <EmailTab />}
       </div>
+
+      {/* Sort portal */}
+      {sortDropdown.open && sortDropdown.rect && createPortal(
+        <div
+          style={{
+            position: "fixed",
+            top: sortDropdown.rect.bottom + 8,
+            left: sortDropdown.rect.right - 180,
+            zIndex: 9999,
+            backgroundColor: "white",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+          }}
+          className="min-w-[180px] rounded-lg p-4"
+        >
+          <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Sort by</p>
+          {(
+            [
+              ["date-desc", "Date: newest first"],
+              ["date-asc", "Date: oldest first"],
+              ["name-asc", "Name A → Z"],
+              ["name-desc", "Name Z → A"],
+              ["amount-desc", "Amount: high to low"],
+              ["amount-asc", "Amount: low to high"],
+            ] as [ContributorSortBy, string][]
+          ).map(([value, label]) => (
+            <label key={value} className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+              <input
+                type="radio"
+                name="contributorSort"
+                checked={sortBy === value}
+                onChange={() => { setSortBy(value); sortDropdown.setOpen(false); }}
+              />
+              {label}
+            </label>
+          ))}
+        </div>,
+        document.body
+      )}
     </DashboardTemplate>
   );
 };

--- a/frontend/src/app/contributors/page.tsx
+++ b/frontend/src/app/contributors/page.tsx
@@ -2,8 +2,9 @@
 
 export const dynamic = "force-dynamic";
 
-import { useState, useRef, useEffect } from "react";
+import React, { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
+import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import ContributorsTable from "@/components/molecules/ContributorsTable";
 import AddContributorModal from "@/components/molecules/AddContributorModal";
@@ -46,21 +47,94 @@ interface ContributorItem {
   transactions: { amount: number; type: string }[];
 }
 
-const TEMPLATES = [
-  { title: "Contact a contributor", tag: "Donor Relations", tagColor: "bg-yellow-100 text-yellow-700" },
-  { title: "Invite new contributors", tag: "Donor Relations", tagColor: "bg-yellow-100 text-yellow-700" },
-  { title: "Send a report", tag: "Report", tagColor: "bg-blue-100 text-blue-700" },
-  { title: "Thank a contributor", tag: "Donor Relations", tagColor: "bg-yellow-100 text-yellow-700" },
+interface EmailTemplate {
+  title: string;
+  tag: string;
+  tagStyle: React.CSSProperties;
+  subject: string;
+  body: string;
+}
+
+const TEMPLATES: EmailTemplate[] = [
+  {
+    title: "Contact a contributor",
+    tag: "Donor Relations",
+    tagStyle: { backgroundColor: "#fdf3dc", color: "#a07830", border: "1px solid #e8d5a0" },
+    subject: "",
+    body: "",
+  },
+  {
+    title: "Invite new contributors",
+    tag: "Donor Relations",
+    tagStyle: { backgroundColor: "#fdf3dc", color: "#a07830", border: "1px solid #e8d5a0" },
+    subject: "",
+    body: "",
+  },
+  {
+    title: "Send a report",
+    tag: "Report",
+    tagStyle: { backgroundColor: "#e8f0fe", color: "#4a6fa5", border: "1px solid #c5d5f5" },
+    subject: "",
+    body: "",
+  },
+  {
+    title: "Thank a contributor",
+    tag: "Donor Relations",
+    tagStyle: { backgroundColor: "#fdf3dc", color: "#a07830", border: "1px solid #e8d5a0" },
+    subject: "",
+    body: "",
+  },
 ];
 
 function EmailTab() {
   const [contributors, setContributors] = useState<ContributorItem[]>([]);
   const [toQuery, setToQuery] = useState("");
   const [toOpen, setToOpen] = useState(false);
-  const [selectedContributor, setSelectedContributor] = useState<ContributorItem | null>(null);
+  const [selectedContributors, setSelectedContributors] = useState<ContributorItem[]>([]);
   const [subject, setSubject] = useState("");
   const [message, setMessage] = useState("");
+  const [activeTemplate, setActiveTemplate] = useState<EmailTemplate | null>(null);
+  const [tmplSelectedContributors, setTmplSelectedContributors] = useState<ContributorItem[]>([]);
+  const [tmplToQuery, setTmplToQuery] = useState("");
+  const [tmplToOpen, setTmplToOpen] = useState(false);
+  const [tmplToRect, setTmplToRect] = useState<DOMRect | null>(null);
+  const tmplWrapRef = useRef<HTMLDivElement>(null);
+  const tmplDropRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!tmplToOpen) return;
+    const handler = (e: MouseEvent) => {
+      const inWrap = tmplWrapRef.current?.contains(e.target as Node);
+      const inDrop = tmplDropRef.current?.contains(e.target as Node);
+      if (!inWrap && !inDrop) setTmplToOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [tmplToOpen]);
+
+  const tmplFilteredContributors = contributors.filter((c) =>
+    !tmplSelectedContributors.some((s) => s.id === c.id) &&
+    `${c.firstName} ${c.lastName}`.toLowerCase().includes(tmplToQuery.toLowerCase())
+  );
   const toRef = useRef<HTMLDivElement>(null);
+  const toPortalRef = useRef<HTMLDivElement>(null);
+  const [toRect, setToRect] = React.useState<DOMRect | null>(null);
+  const [listFilter, setListFilter] = React.useState<"last-month" | "last-year" | "all-time">("last-month");
+  const [listFilterOpen, setListFilterOpen] = React.useState(false);
+  const [listFilterRect, setListFilterRect] = React.useState<DOMRect | null>(null);
+  const listFilterRef = useRef<HTMLButtonElement>(null);
+  const listFilterPortalRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!listFilterOpen) return;
+    const handler = (e: MouseEvent) => {
+      const inButton = listFilterRef.current?.contains(e.target as Node);
+      const inPortal = listFilterPortalRef.current?.contains(e.target as Node);
+      if (!inButton && !inPortal) setListFilterOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [listFilterOpen]);
 
   useEffect(() => {
     api.get("/contributors").then((res) => {
@@ -71,24 +145,40 @@ function EmailTab() {
   useEffect(() => {
     if (!toOpen) return;
     const handler = (e: MouseEvent) => {
-      if (toRef.current && !toRef.current.contains(e.target as Node)) setToOpen(false);
+      const inInput = toRef.current?.contains(e.target as Node);
+      const inPortal = toPortalRef.current?.contains(e.target as Node);
+      if (!inInput && !inPortal) setToOpen(false);
     };
     document.addEventListener("mousedown", handler);
     return () => document.removeEventListener("mousedown", handler);
   }, [toOpen]);
 
+  const filterCutoff = React.useMemo(() => {
+    const d = new Date();
+    if (listFilter === "last-month") { d.setMonth(d.getMonth() - 1); return d; }
+    if (listFilter === "last-year") { d.setFullYear(d.getFullYear() - 1); return d; }
+    return null;
+  }, [listFilter]);
+
   const topContributors = [...contributors]
     .map((c) => ({
       ...c,
       total: c.transactions
-        .filter((t) => t.type === "DONATION" || t.type === "INVESTMENT")
+        .filter((t) =>
+          (t.type === "DONATION" || t.type === "INVESTMENT") &&
+          (filterCutoff ? new Date((t as any).date ?? 0) >= filterCutoff : true)
+        )
         .reduce((s, t) => s + t.amount, 0),
       fund: c.funds?.[0]?.name ?? "—",
     }))
+    .filter((c) => c.total > 0)
     .sort((a, b) => b.total - a.total)
     .slice(0, 6);
 
+  const listFilterLabel = listFilter === "last-month" ? "Last Month's" : listFilter === "last-year" ? "Last Year's" : "All Time";
+
   const filteredContributors = contributors.filter((c) =>
+    !selectedContributors.some((s) => s.id === c.id) &&
     `${c.firstName} ${c.lastName}`.toLowerCase().includes(toQuery.toLowerCase())
   );
 
@@ -99,24 +189,175 @@ function EmailTab() {
     <div className="space-y-8">
       {/* Templates */}
       <div>
-        <div className="mb-4 flex items-center justify-between">
+        <div className="mb-4">
           <h2 className="text-xl font-bold">Templates</h2>
-          <button className="flex items-center gap-1 text-sm text-blue-500 hover:underline">
-            See more →
-          </button>
         </div>
         <div className="grid grid-cols-4 gap-4">
           {TEMPLATES.map((t) => (
             <button
               key={t.title}
+              onClick={() => setActiveTemplate(t)}
               className="flex h-36 flex-col justify-between rounded-xl border border-gray-200 bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md"
             >
-              <p className="text-sm font-semibold leading-snug">{t.title}</p>
-              <span className={`w-fit rounded px-2 py-0.5 text-xs font-medium ${t.tagColor}`}>{t.tag}</span>
+              <p className="text-sm font-semibold leading-snug text-gray-900">{t.title}</p>
+              <span className="w-fit rounded px-2 py-0.5 text-xs font-medium" style={t.tagStyle}>{t.tag}</span>
             </button>
           ))}
         </div>
       </div>
+
+      {/* Template modal */}
+      <Dialog open={activeTemplate !== null} onOpenChange={(o) => { if (!o) { setActiveTemplate(null); setTmplSelectedContributors([]); setTmplToQuery(""); setTmplToOpen(false); } }}>
+        <DialogContent
+          className="max-w-3xl p-0 gap-0 overflow-visible"
+          onPointerDownOutside={(e) => {
+            const target = e.target as HTMLElement;
+            if (tmplDropRef.current?.contains(target)) e.preventDefault();
+          }}
+          onInteractOutside={(e) => {
+            const target = e.target as HTMLElement;
+            if (tmplDropRef.current?.contains(target)) e.preventDefault();
+          }}
+        >
+          <DialogTitle className="sr-only">{activeTemplate?.title ?? "Email template"}</DialogTitle>
+
+          {/* Header */}
+          <div className="flex items-center gap-3 border-b border-gray-100 px-6 py-4">
+            <span className="text-lg font-bold text-gray-900">New Email</span>
+            {activeTemplate && (
+              <span className="rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-600">
+                {activeTemplate.title}
+              </span>
+            )}
+          </div>
+
+          {/* Fields */}
+          <div className="divide-y divide-gray-100 px-6">
+            {/* Contributors row */}
+            <div className="flex items-start gap-3 py-4">
+              <span className="w-24 shrink-0 pt-0.5 text-sm text-gray-500">Contributors</span>
+              <div
+                ref={tmplWrapRef}
+                className="flex flex-1 flex-wrap gap-1.5 cursor-text"
+                onClick={() => {
+                  if (tmplWrapRef.current) setTmplToRect(tmplWrapRef.current.getBoundingClientRect());
+                  setTmplToOpen(true);
+                }}
+              >
+                {tmplSelectedContributors.map((c) => (
+                  <span key={c.id} className="flex items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
+                    {c.firstName} {c.lastName}
+                    <button
+                      className="ml-0.5 text-gray-400 hover:text-gray-600"
+                      onMouseDown={(e) => { e.stopPropagation(); setTmplSelectedContributors((prev) => prev.filter((s) => s.id !== c.id)); }}
+                    >×</button>
+                  </span>
+                ))}
+                <input
+                  type="text"
+                  placeholder={tmplSelectedContributors.length === 0 ? "Add contributors…" : "Add more…"}
+                  value={tmplToQuery}
+                  onFocus={() => {
+                    if (tmplWrapRef.current) setTmplToRect(tmplWrapRef.current.getBoundingClientRect());
+                    setTmplToOpen(true);
+                  }}
+                  onChange={(e) => {
+                    setTmplToQuery(e.target.value);
+                    if (tmplWrapRef.current) setTmplToRect(tmplWrapRef.current.getBoundingClientRect());
+                    setTmplToOpen(true);
+                  }}
+                  className="min-w-[140px] flex-1 text-sm outline-none placeholder:text-gray-400 bg-transparent"
+                />
+              </div>
+            </div>
+            {tmplToOpen && tmplToRect && createPortal(
+              <div
+                ref={tmplDropRef}
+                style={{
+                  position: "fixed",
+                  top: tmplToRect.bottom + 4,
+                  left: tmplToRect.left,
+                  width: Math.max(tmplToRect.width, 220),
+                  zIndex: 9999,
+                  backgroundColor: "white",
+                  boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+                  borderRadius: 8,
+                  pointerEvents: "auto",
+                }}
+              >
+                {tmplFilteredContributors.length === 0 ? (
+                  <p className="px-3 py-2 text-sm text-gray-400">No contributors found</p>
+                ) : (
+                  tmplFilteredContributors.slice(0, 8).map((c) => (
+                    <button
+                      key={c.id}
+                      className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                      onMouseDown={(e) => {
+                        e.preventDefault();
+                        setTmplSelectedContributors((prev) => [...prev, c]);
+                        setTmplToQuery("");
+                      }}
+                    >
+                      {c.firstName} {c.lastName}
+                    </button>
+                  ))
+                )}
+              </div>,
+              document.body
+            )}
+
+            {/* Subject row */}
+            <div className="flex items-center gap-3 py-4">
+              <span className="w-24 shrink-0 text-sm text-gray-500">Subject</span>
+              <input
+                type="text"
+                placeholder="Subject"
+                defaultValue={activeTemplate?.subject ?? ""}
+                className="flex-1 text-sm outline-none placeholder:text-gray-400"
+              />
+            </div>
+          </div>
+
+          {/* Message */}
+          <div className="px-6 pt-4 pb-2">
+            <div className="mb-2 flex items-center justify-between">
+              <span className="text-sm font-semibold text-gray-800">Message</span>
+              <div className="flex items-center gap-3 text-gray-400">
+                <button title="Attach" className="hover:text-gray-600">↑</button>
+                <button title="Link" className="hover:text-gray-600">🔗</button>
+                <button title="Image" className="hover:text-gray-600">🖼</button>
+                <button title="Bold" className="hover:text-gray-600 font-bold text-sm">B</button>
+                <button title="Italic" className="hover:text-gray-600 text-sm italic">I</button>
+                <button title="Bullet list" className="hover:text-gray-600">☰</button>
+                <button title="Numbered list" className="hover:text-gray-600">≣</button>
+              </div>
+            </div>
+            <textarea
+              placeholder="Type a message"
+              defaultValue={activeTemplate?.body ?? ""}
+              rows={10}
+              className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-gray-800 outline-none placeholder:text-gray-400 focus:border-gray-300"
+            />
+          </div>
+
+          {/* Footer */}
+          <div className="flex justify-end gap-3 border-t border-gray-100 px-6 py-4">
+            <button
+              onClick={() => { setActiveTemplate(null); setTmplSelectedContributors([]); setTmplToQuery(""); setTmplToOpen(false); }}
+              className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              className="rounded-xl px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+              style={{ backgroundColor: "#e4e4e4" }}
+              onClick={() => { setActiveTemplate(null); setTmplSelectedContributors([]); setTmplToQuery(""); setTmplToOpen(false); }}
+            >
+              Send Email
+            </button>
+          </div>
+        </DialogContent>
+      </Dialog>
 
       {/* Send an Email */}
       <div>
@@ -127,8 +368,16 @@ function EmailTab() {
           <div className="w-72 shrink-0 rounded-xl border border-gray-200 bg-white shadow-sm">
             {/* Header */}
             <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
-              <span className="text-sm font-medium text-gray-800">Last Month's Top Contributors</span>
-              <FilterListIcon fontSize="small" style={{ color: "#3E6DA6" }} />
+              <span className="text-sm font-medium text-gray-800">{listFilterLabel} Top Contributors</span>
+              <button
+                ref={listFilterRef}
+                onClick={() => {
+                  if (listFilterRef.current) setListFilterRect(listFilterRef.current.getBoundingClientRect());
+                  setListFilterOpen((o) => !o);
+                }}
+              >
+                <FilterListIcon fontSize="small" style={{ color: "#3E6DA6" }} />
+              </button>
             </div>
             {/* Rows */}
             <div className="divide-y divide-gray-50 px-4">
@@ -136,7 +385,16 @@ function EmailTab() {
                 <p className="py-4 text-xs text-gray-400">No contributors yet</p>
               ) : (
                 topContributors.map((c) => (
-                  <div key={c.id} className="flex items-center justify-between py-3">
+                  <div
+                    key={c.id}
+                    className="flex cursor-pointer items-center justify-between py-3 hover:bg-gray-50 -mx-4 px-4 rounded"
+                    onClick={() => {
+                      if (!selectedContributors.some((s) => s.id === c.id)) {
+                        setSelectedContributors((prev) => [...prev, c]);
+                      }
+                      setToQuery("");
+                    }}
+                  >
                     <div>
                       <p className="text-sm font-semibold text-gray-900">{c.firstName} {c.lastName}</p>
                       <p className="text-xs text-gray-400">{c.fund}</p>
@@ -160,48 +418,82 @@ function EmailTab() {
               {/* To */}
               <div>
                 <label className="mb-1.5 block text-sm font-semibold text-gray-800">To</label>
-                <div className="relative" ref={toRef}>
+                <div ref={toRef}>
                   <div
-                    className="flex cursor-text items-center justify-between rounded-lg border border-gray-300 bg-white px-3 py-2.5"
-                    onClick={() => setToOpen(true)}
+                    className="flex flex-wrap cursor-text items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2"
+                    onClick={() => {
+                      if (toRef.current) setToRect(toRef.current.getBoundingClientRect());
+                      setToOpen(true);
+                    }}
                   >
-                    {selectedContributor ? (
-                      <span className="text-sm text-gray-800">{selectedContributor.firstName} {selectedContributor.lastName}</span>
-                    ) : (
-                      <input
-                        type="text"
-                        placeholder="Type a contributor"
-                        value={toQuery}
-                        onChange={(e) => { setToQuery(e.target.value); setToOpen(true); }}
-                        className="w-full bg-transparent text-sm text-gray-500 outline-none placeholder:text-gray-400"
-                      />
-                    )}
-                    <svg className="h-4 w-4 shrink-0 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-                    </svg>
+                    {selectedContributors.map((c) => (
+                      <span
+                        key={c.id}
+                        className="flex items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700"
+                      >
+                        {c.firstName} {c.lastName}
+                        <button
+                          className="ml-0.5 text-gray-400 hover:text-gray-600"
+                          onMouseDown={(e) => {
+                            e.stopPropagation();
+                            setSelectedContributors((prev) => prev.filter((s) => s.id !== c.id));
+                          }}
+                        >
+                          ×
+                        </button>
+                      </span>
+                    ))}
+                    <input
+                      type="text"
+                      placeholder={selectedContributors.length === 0 ? "Type a contributor" : "Add more…"}
+                      value={toQuery}
+                      onFocus={() => {
+                        if (toRef.current) setToRect(toRef.current.getBoundingClientRect());
+                        setToOpen(true);
+                      }}
+                      onChange={(e) => {
+                        setToQuery(e.target.value);
+                        if (toRef.current) setToRect(toRef.current.getBoundingClientRect());
+                        setToOpen(true);
+                      }}
+                      className="min-w-[120px] flex-1 bg-transparent text-sm text-gray-500 outline-none placeholder:text-gray-400"
+                    />
                   </div>
-                  {toOpen && (
-                    <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-lg border border-gray-200 bg-white shadow-lg">
-                      {filteredContributors.length === 0 ? (
-                        <p className="px-3 py-2 text-sm text-gray-400">No contributors found</p>
-                      ) : (
-                        filteredContributors.slice(0, 8).map((c) => (
-                          <button
-                            key={c.id}
-                            className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-                            onClick={() => { setSelectedContributor(c); setToQuery(""); setToOpen(false); }}
-                          >
-                            {c.firstName} {c.lastName}
-                          </button>
-                        ))
-                      )}
-                    </div>
-                  )}
                 </div>
-                {selectedContributor && (
-                  <button className="mt-1 text-xs text-gray-400 underline" onClick={() => setSelectedContributor(null)}>
-                    Clear
-                  </button>
+                {toOpen && toRect && createPortal(
+                  <div
+                    ref={toPortalRef}
+                    style={{
+                      position: "fixed",
+                      top: toRect.bottom + 4,
+                      left: toRect.left,
+                      width: toRect.width,
+                      zIndex: 9999,
+                      backgroundColor: "white",
+                      boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+                    }}
+                    className="rounded-lg"
+                  >
+                    {filteredContributors.length === 0 ? (
+                      <p className="px-3 py-2 text-sm text-gray-400">No contributors found</p>
+                    ) : (
+                      filteredContributors.slice(0, 8).map((c) => (
+                        <button
+                          key={c.id}
+                          className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
+                          onMouseDown={(e) => {
+                            e.preventDefault();
+                            setSelectedContributors((prev) => [...prev, c]);
+                            setToQuery("");
+                            setToOpen(false);
+                          }}
+                        >
+                          {c.firstName} {c.lastName}
+                        </button>
+                      ))
+                    )}
+                  </div>,
+                  document.body
                 )}
               </div>
 
@@ -245,11 +537,11 @@ function EmailTab() {
             <div className="flex justify-end gap-3 border-t border-gray-100 px-6 py-4">
               <button
                 className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                onClick={() => { setSelectedContributor(null); setSubject(""); setMessage(""); }}
+                onClick={() => { setSelectedContributors([]); setToQuery(""); setSubject(""); setMessage(""); }}
               >
                 Cancel
               </button>
-              <button className="rounded-lg bg-gray-700 px-5 py-2 text-sm font-medium text-white hover:bg-gray-800">
+              <button className="rounded-xl px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200" style={{ backgroundColor: "#e4e4e4" }}>
                 Send Email
               </button>
             </div>
@@ -257,6 +549,37 @@ function EmailTab() {
 
         </div>
       </div>
+
+      {/* List filter portal */}
+      {listFilterOpen && listFilterRect && createPortal(
+        <div
+          ref={listFilterPortalRef}
+          style={{
+            position: "fixed",
+            top: listFilterRect.bottom + 6,
+            left: listFilterRect.right - 160,
+            zIndex: 9999,
+            backgroundColor: "white",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+          }}
+          className="min-w-[160px] rounded-lg p-2"
+        >
+          {([
+            ["last-month", "Last Month's"],
+            ["last-year", "Last Year's"],
+            ["all-time", "All Time"],
+          ] as ["last-month" | "last-year" | "all-time", string][]).map(([val, label]) => (
+            <button
+              key={val}
+              className={`w-full rounded px-3 py-2 text-left text-sm hover:bg-gray-50 ${listFilter === val ? "font-semibold text-blue-600" : "text-gray-700"}`}
+              onMouseDown={(e) => { e.preventDefault(); setListFilter(val); setListFilterOpen(false); }}
+            >
+              {label}
+            </button>
+          ))}
+        </div>,
+        document.body
+      )}
     </div>
   );
 }

--- a/frontend/src/app/contributors/page.tsx
+++ b/frontend/src/app/contributors/page.tsx
@@ -100,8 +100,8 @@ function EmailTab() {
       {/* Templates */}
       <div>
         <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-xl font-bold text-white">Templates</h2>
-          <button className="flex items-center gap-1 text-sm text-blue-300 hover:underline">
+          <h2 className="text-xl font-bold">Templates</h2>
+          <button className="flex items-center gap-1 text-sm text-blue-500 hover:underline">
             See more →
           </button>
         </div>
@@ -120,7 +120,7 @@ function EmailTab() {
 
       {/* Send an Email */}
       <div>
-        <h2 className="mb-4 text-xl font-bold text-white">Send an Email</h2>
+        <h2 className="mb-4 text-xl font-bold">Send an Email</h2>
         <div className="flex gap-4 items-start">
 
           {/* Left: top contributors */}

--- a/frontend/src/app/contributors/page.tsx
+++ b/frontend/src/app/contributors/page.tsx
@@ -2,18 +2,20 @@
 
 export const dynamic = "force-dynamic";
 
-import React, { useState, useRef, useEffect } from "react";
+import { useState, useRef, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import ContributorsTable from "@/components/molecules/ContributorsTable";
 import AddContributorModal from "@/components/molecules/AddContributorModal";
 import SearchBar from "@/components/molecules/Searchbar";
-import FilterListIcon from "@mui/icons-material/FilterList";
+import Button from "@/components/atoms/Button";
+import SwapVertIcon from "@mui/icons-material/SwapVert";
+import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import LaunchIcon from "@mui/icons-material/Launch";
-import api from "@/utils/api";
 
 export type ContributorSortBy = "date-desc" | "date-asc" | "name-asc" | "name-desc" | "amount-desc" | "amount-asc";
+
+const buttonColor = "#838383";
 
 function useDropdown() {
   const [open, setOpen] = useState(false);
@@ -37,559 +39,9 @@ function useDropdown() {
   return { open, setOpen, toggle, rect, buttonRef };
 }
 
-// ── Email tab ──────────────────────────────────────────────────────────────
-
-interface ContributorItem {
-  id: string;
-  firstName: string;
-  lastName: string;
-  funds: { id: string; name: string }[];
-  transactions: { amount: number; type: string }[];
-}
-
-interface EmailTemplate {
-  title: string;
-  tag: string;
-  tagStyle: React.CSSProperties;
-  subject: string;
-  body: string;
-}
-
-const TEMPLATES: EmailTemplate[] = [
-  {
-    title: "Contact a contributor",
-    tag: "Donor Relations",
-    tagStyle: { backgroundColor: "#fdf3dc", color: "#a07830", border: "1px solid #e8d5a0" },
-    subject: "",
-    body: "",
-  },
-  {
-    title: "Invite new contributors",
-    tag: "Donor Relations",
-    tagStyle: { backgroundColor: "#fdf3dc", color: "#a07830", border: "1px solid #e8d5a0" },
-    subject: "",
-    body: "",
-  },
-  {
-    title: "Send a report",
-    tag: "Report",
-    tagStyle: { backgroundColor: "#e8f0fe", color: "#4a6fa5", border: "1px solid #c5d5f5" },
-    subject: "",
-    body: "",
-  },
-  {
-    title: "Thank a contributor",
-    tag: "Donor Relations",
-    tagStyle: { backgroundColor: "#fdf3dc", color: "#a07830", border: "1px solid #e8d5a0" },
-    subject: "",
-    body: "",
-  },
-];
-
-function EmailTab() {
-  const [contributors, setContributors] = useState<ContributorItem[]>([]);
-  const [toQuery, setToQuery] = useState("");
-  const [toOpen, setToOpen] = useState(false);
-  const [selectedContributors, setSelectedContributors] = useState<ContributorItem[]>([]);
-  const [subject, setSubject] = useState("");
-  const [message, setMessage] = useState("");
-  const [activeTemplate, setActiveTemplate] = useState<EmailTemplate | null>(null);
-  const [tmplSelectedContributors, setTmplSelectedContributors] = useState<ContributorItem[]>([]);
-  const [tmplToQuery, setTmplToQuery] = useState("");
-  const [tmplToOpen, setTmplToOpen] = useState(false);
-  const [tmplToRect, setTmplToRect] = useState<DOMRect | null>(null);
-  const tmplWrapRef = useRef<HTMLDivElement>(null);
-  const tmplDropRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!tmplToOpen) return;
-    const handler = (e: MouseEvent) => {
-      const inWrap = tmplWrapRef.current?.contains(e.target as Node);
-      const inDrop = tmplDropRef.current?.contains(e.target as Node);
-      if (!inWrap && !inDrop) setTmplToOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [tmplToOpen]);
-
-  const tmplFilteredContributors = contributors.filter((c) =>
-    !tmplSelectedContributors.some((s) => s.id === c.id) &&
-    `${c.firstName} ${c.lastName}`.toLowerCase().includes(tmplToQuery.toLowerCase())
-  );
-  const toRef = useRef<HTMLDivElement>(null);
-  const toPortalRef = useRef<HTMLDivElement>(null);
-  const [toRect, setToRect] = React.useState<DOMRect | null>(null);
-  const [listFilter, setListFilter] = React.useState<"last-month" | "last-year" | "all-time">("last-month");
-  const [listFilterOpen, setListFilterOpen] = React.useState(false);
-  const [listFilterRect, setListFilterRect] = React.useState<DOMRect | null>(null);
-  const listFilterRef = useRef<HTMLButtonElement>(null);
-  const listFilterPortalRef = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!listFilterOpen) return;
-    const handler = (e: MouseEvent) => {
-      const inButton = listFilterRef.current?.contains(e.target as Node);
-      const inPortal = listFilterPortalRef.current?.contains(e.target as Node);
-      if (!inButton && !inPortal) setListFilterOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [listFilterOpen]);
-
-  useEffect(() => {
-    api.get("/contributors").then((res) => {
-      setContributors(res.data.contributors ?? []);
-    }).catch(() => {});
-  }, []);
-
-  useEffect(() => {
-    if (!toOpen) return;
-    const handler = (e: MouseEvent) => {
-      const inInput = toRef.current?.contains(e.target as Node);
-      const inPortal = toPortalRef.current?.contains(e.target as Node);
-      if (!inInput && !inPortal) setToOpen(false);
-    };
-    document.addEventListener("mousedown", handler);
-    return () => document.removeEventListener("mousedown", handler);
-  }, [toOpen]);
-
-  const filterCutoff = React.useMemo(() => {
-    const d = new Date();
-    if (listFilter === "last-month") { d.setMonth(d.getMonth() - 1); return d; }
-    if (listFilter === "last-year") { d.setFullYear(d.getFullYear() - 1); return d; }
-    return null;
-  }, [listFilter]);
-
-  const topContributors = [...contributors]
-    .map((c) => ({
-      ...c,
-      total: c.transactions
-        .filter((t) =>
-          (t.type === "DONATION" || t.type === "INVESTMENT") &&
-          (filterCutoff ? new Date((t as any).date ?? 0) >= filterCutoff : true)
-        )
-        .reduce((s, t) => s + t.amount, 0),
-      fund: c.funds?.[0]?.name ?? "—",
-    }))
-    .filter((c) => c.total > 0)
-    .sort((a, b) => b.total - a.total)
-    .slice(0, 6);
-
-  const listFilterLabel = listFilter === "last-month" ? "Last Month's" : listFilter === "last-year" ? "Last Year's" : "All Time";
-
-  const filteredContributors = contributors.filter((c) =>
-    !selectedContributors.some((s) => s.id === c.id) &&
-    `${c.firstName} ${c.lastName}`.toLowerCase().includes(toQuery.toLowerCase())
-  );
-
-  const fmtAmt = (n: number) =>
-    new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(n);
-
-  return (
-    <div className="space-y-8">
-      {/* Templates */}
-      <div>
-        <div className="mb-4">
-          <h2 className="text-xl font-bold">Templates</h2>
-        </div>
-        <div className="grid grid-cols-4 gap-4">
-          {TEMPLATES.map((t) => (
-            <button
-              key={t.title}
-              onClick={() => setActiveTemplate(t)}
-              className="flex h-36 flex-col justify-between rounded-xl border border-gray-200 bg-white p-5 text-left shadow-sm transition-shadow hover:shadow-md"
-            >
-              <p className="text-sm font-semibold leading-snug text-gray-900">{t.title}</p>
-              <span className="w-fit rounded px-2 py-0.5 text-xs font-medium" style={t.tagStyle}>{t.tag}</span>
-            </button>
-          ))}
-        </div>
-      </div>
-
-      {/* Template modal */}
-      <Dialog open={activeTemplate !== null} onOpenChange={(o) => { if (!o) { setActiveTemplate(null); setTmplSelectedContributors([]); setTmplToQuery(""); setTmplToOpen(false); } }}>
-        <DialogContent
-          className="max-w-3xl p-0 gap-0 overflow-visible"
-          onPointerDownOutside={(e) => {
-            const target = e.target as HTMLElement;
-            if (tmplDropRef.current?.contains(target)) e.preventDefault();
-          }}
-          onInteractOutside={(e) => {
-            const target = e.target as HTMLElement;
-            if (tmplDropRef.current?.contains(target)) e.preventDefault();
-          }}
-        >
-          <DialogTitle className="sr-only">{activeTemplate?.title ?? "Email template"}</DialogTitle>
-
-          {/* Header */}
-          <div className="flex items-center gap-3 border-b border-gray-100 px-6 py-4">
-            <span className="text-lg font-bold text-gray-900">New Email</span>
-            {activeTemplate && (
-              <span className="rounded-full bg-gray-100 px-3 py-1 text-sm font-medium text-gray-600">
-                {activeTemplate.title}
-              </span>
-            )}
-          </div>
-
-          {/* Fields */}
-          <div className="divide-y divide-gray-100 px-6">
-            {/* Contributors row */}
-            <div className="flex items-start gap-3 py-4">
-              <span className="w-24 shrink-0 pt-0.5 text-sm text-gray-500">Contributors</span>
-              <div
-                ref={tmplWrapRef}
-                className="flex flex-1 flex-wrap gap-1.5 cursor-text"
-                onClick={() => {
-                  if (tmplWrapRef.current) setTmplToRect(tmplWrapRef.current.getBoundingClientRect());
-                  setTmplToOpen(true);
-                }}
-              >
-                {tmplSelectedContributors.map((c) => (
-                  <span key={c.id} className="flex items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700">
-                    {c.firstName} {c.lastName}
-                    <button
-                      className="ml-0.5 text-gray-400 hover:text-gray-600"
-                      onMouseDown={(e) => { e.stopPropagation(); setTmplSelectedContributors((prev) => prev.filter((s) => s.id !== c.id)); }}
-                    >×</button>
-                  </span>
-                ))}
-                <input
-                  type="text"
-                  placeholder={tmplSelectedContributors.length === 0 ? "Add contributors…" : "Add more…"}
-                  value={tmplToQuery}
-                  onFocus={() => {
-                    if (tmplWrapRef.current) setTmplToRect(tmplWrapRef.current.getBoundingClientRect());
-                    setTmplToOpen(true);
-                  }}
-                  onChange={(e) => {
-                    setTmplToQuery(e.target.value);
-                    if (tmplWrapRef.current) setTmplToRect(tmplWrapRef.current.getBoundingClientRect());
-                    setTmplToOpen(true);
-                  }}
-                  className="min-w-[140px] flex-1 text-sm outline-none placeholder:text-gray-400 bg-transparent"
-                />
-              </div>
-            </div>
-            {tmplToOpen && tmplToRect && createPortal(
-              <div
-                ref={tmplDropRef}
-                style={{
-                  position: "fixed",
-                  top: tmplToRect.bottom + 4,
-                  left: tmplToRect.left,
-                  width: Math.max(tmplToRect.width, 220),
-                  zIndex: 9999,
-                  backgroundColor: "white",
-                  boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
-                  borderRadius: 8,
-                  pointerEvents: "auto",
-                }}
-              >
-                {tmplFilteredContributors.length === 0 ? (
-                  <p className="px-3 py-2 text-sm text-gray-400">No contributors found</p>
-                ) : (
-                  tmplFilteredContributors.slice(0, 8).map((c) => (
-                    <button
-                      key={c.id}
-                      className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-                      onMouseDown={(e) => {
-                        e.preventDefault();
-                        setTmplSelectedContributors((prev) => [...prev, c]);
-                        setTmplToQuery("");
-                      }}
-                    >
-                      {c.firstName} {c.lastName}
-                    </button>
-                  ))
-                )}
-              </div>,
-              document.body
-            )}
-
-            {/* Subject row */}
-            <div className="flex items-center gap-3 py-4">
-              <span className="w-24 shrink-0 text-sm text-gray-500">Subject</span>
-              <input
-                type="text"
-                placeholder="Subject"
-                defaultValue={activeTemplate?.subject ?? ""}
-                className="flex-1 text-sm outline-none placeholder:text-gray-400"
-              />
-            </div>
-          </div>
-
-          {/* Message */}
-          <div className="px-6 pt-4 pb-2">
-            <div className="mb-2 flex items-center justify-between">
-              <span className="text-sm font-semibold text-gray-800">Message</span>
-              <div className="flex items-center gap-3 text-gray-400">
-                <button title="Attach" className="hover:text-gray-600">↑</button>
-                <button title="Link" className="hover:text-gray-600">🔗</button>
-                <button title="Image" className="hover:text-gray-600">🖼</button>
-                <button title="Bold" className="hover:text-gray-600 font-bold text-sm">B</button>
-                <button title="Italic" className="hover:text-gray-600 text-sm italic">I</button>
-                <button title="Bullet list" className="hover:text-gray-600">☰</button>
-                <button title="Numbered list" className="hover:text-gray-600">≣</button>
-              </div>
-            </div>
-            <textarea
-              placeholder="Type a message"
-              defaultValue={activeTemplate?.body ?? ""}
-              rows={10}
-              className="w-full resize-none rounded-lg border border-gray-200 px-3 py-2.5 text-sm text-gray-800 outline-none placeholder:text-gray-400 focus:border-gray-300"
-            />
-          </div>
-
-          {/* Footer */}
-          <div className="flex justify-end gap-3 border-t border-gray-100 px-6 py-4">
-            <button
-              onClick={() => { setActiveTemplate(null); setTmplSelectedContributors([]); setTmplToQuery(""); setTmplToOpen(false); }}
-              className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-            >
-              Cancel
-            </button>
-            <button
-              className="rounded-xl px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
-              style={{ backgroundColor: "#e4e4e4" }}
-              onClick={() => { setActiveTemplate(null); setTmplSelectedContributors([]); setTmplToQuery(""); setTmplToOpen(false); }}
-            >
-              Send Email
-            </button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Send an Email */}
-      <div>
-        <h2 className="mb-4 text-xl font-bold">Send an Email</h2>
-        <div className="flex gap-4 items-start">
-
-          {/* Left: top contributors */}
-          <div className="w-72 shrink-0 rounded-xl border border-gray-200 bg-white shadow-sm">
-            {/* Header */}
-            <div className="flex items-center justify-between border-b border-gray-100 px-4 py-3">
-              <span className="text-sm font-medium text-gray-800">{listFilterLabel} Top Contributors</span>
-              <button
-                ref={listFilterRef}
-                onClick={() => {
-                  if (listFilterRef.current) setListFilterRect(listFilterRef.current.getBoundingClientRect());
-                  setListFilterOpen((o) => !o);
-                }}
-              >
-                <FilterListIcon fontSize="small" style={{ color: "#3E6DA6" }} />
-              </button>
-            </div>
-            {/* Rows */}
-            <div className="divide-y divide-gray-50 px-4">
-              {topContributors.length === 0 ? (
-                <p className="py-4 text-xs text-gray-400">No contributors yet</p>
-              ) : (
-                topContributors.map((c) => (
-                  <div
-                    key={c.id}
-                    className="flex cursor-pointer items-center justify-between py-3 hover:bg-gray-50 -mx-4 px-4 rounded"
-                    onClick={() => {
-                      if (!selectedContributors.some((s) => s.id === c.id)) {
-                        setSelectedContributors((prev) => [...prev, c]);
-                      }
-                      setToQuery("");
-                    }}
-                  >
-                    <div>
-                      <p className="text-sm font-semibold text-gray-900">{c.firstName} {c.lastName}</p>
-                      <p className="text-xs text-gray-400">{c.fund}</p>
-                    </div>
-                    <span className="text-sm font-medium text-green-600">+{fmtAmt(c.total)}</span>
-                  </div>
-                ))
-              )}
-            </div>
-          </div>
-
-          {/* Right: compose */}
-          <div className="flex-1 rounded-xl border border-gray-200 bg-white shadow-sm">
-            {/* Compose header */}
-            <div className="flex items-center justify-between border-b border-gray-100 px-6 py-4">
-              <h3 className="font-semibold text-gray-900">New Email</h3>
-              <button className="text-lg text-gray-400 hover:text-gray-600">↗</button>
-            </div>
-
-            <div className="px-6 py-5 space-y-5">
-              {/* To */}
-              <div>
-                <label className="mb-1.5 block text-sm font-semibold text-gray-800">To</label>
-                <div ref={toRef}>
-                  <div
-                    className="flex flex-wrap cursor-text items-center gap-1.5 rounded-lg border border-gray-300 bg-white px-3 py-2"
-                    onClick={() => {
-                      if (toRef.current) setToRect(toRef.current.getBoundingClientRect());
-                      setToOpen(true);
-                    }}
-                  >
-                    {selectedContributors.map((c) => (
-                      <span
-                        key={c.id}
-                        className="flex items-center gap-1 rounded-full border border-gray-300 bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700"
-                      >
-                        {c.firstName} {c.lastName}
-                        <button
-                          className="ml-0.5 text-gray-400 hover:text-gray-600"
-                          onMouseDown={(e) => {
-                            e.stopPropagation();
-                            setSelectedContributors((prev) => prev.filter((s) => s.id !== c.id));
-                          }}
-                        >
-                          ×
-                        </button>
-                      </span>
-                    ))}
-                    <input
-                      type="text"
-                      placeholder={selectedContributors.length === 0 ? "Type a contributor" : "Add more…"}
-                      value={toQuery}
-                      onFocus={() => {
-                        if (toRef.current) setToRect(toRef.current.getBoundingClientRect());
-                        setToOpen(true);
-                      }}
-                      onChange={(e) => {
-                        setToQuery(e.target.value);
-                        if (toRef.current) setToRect(toRef.current.getBoundingClientRect());
-                        setToOpen(true);
-                      }}
-                      className="min-w-[120px] flex-1 bg-transparent text-sm text-gray-500 outline-none placeholder:text-gray-400"
-                    />
-                  </div>
-                </div>
-                {toOpen && toRect && createPortal(
-                  <div
-                    ref={toPortalRef}
-                    style={{
-                      position: "fixed",
-                      top: toRect.bottom + 4,
-                      left: toRect.left,
-                      width: toRect.width,
-                      zIndex: 9999,
-                      backgroundColor: "white",
-                      boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
-                    }}
-                    className="rounded-lg"
-                  >
-                    {filteredContributors.length === 0 ? (
-                      <p className="px-3 py-2 text-sm text-gray-400">No contributors found</p>
-                    ) : (
-                      filteredContributors.slice(0, 8).map((c) => (
-                        <button
-                          key={c.id}
-                          className="w-full px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50"
-                          onMouseDown={(e) => {
-                            e.preventDefault();
-                            setSelectedContributors((prev) => [...prev, c]);
-                            setToQuery("");
-                            setToOpen(false);
-                          }}
-                        >
-                          {c.firstName} {c.lastName}
-                        </button>
-                      ))
-                    )}
-                  </div>,
-                  document.body
-                )}
-              </div>
-
-              {/* Subject */}
-              <div>
-                <label className="mb-1.5 block text-sm font-semibold text-gray-800">Subject</label>
-                <input
-                  type="text"
-                  placeholder="Type a subject"
-                  value={subject}
-                  onChange={(e) => setSubject(e.target.value)}
-                  className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-800 outline-none placeholder:text-gray-400 focus:border-gray-400"
-                />
-              </div>
-
-              {/* Message */}
-              <div>
-                <div className="mb-1.5 flex items-center justify-between">
-                  <label className="text-sm font-semibold text-gray-800">Message</label>
-                  <div className="flex items-center gap-3 text-gray-400">
-                    <button title="Attach" className="hover:text-gray-600 text-base">↑</button>
-                    <button title="Link" className="hover:text-gray-600 text-base">🔗</button>
-                    <button title="Image" className="hover:text-gray-600 text-base">🖼</button>
-                    <button title="Bold" className="hover:text-gray-600 text-sm font-bold">B</button>
-                    <button title="Italic" className="hover:text-gray-600 text-sm italic">I</button>
-                    <button title="Bullet list" className="hover:text-gray-600 text-base">☰</button>
-                    <button title="Numbered list" className="hover:text-gray-600 text-base">≣</button>
-                  </div>
-                </div>
-                <textarea
-                  placeholder="Type a message"
-                  value={message}
-                  onChange={(e) => setMessage(e.target.value)}
-                  rows={8}
-                  className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2.5 text-sm text-gray-800 outline-none placeholder:text-gray-400 focus:border-gray-400"
-                />
-              </div>
-            </div>
-
-            {/* Footer */}
-            <div className="flex justify-end gap-3 border-t border-gray-100 px-6 py-4">
-              <button
-                className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
-                onClick={() => { setSelectedContributors([]); setToQuery(""); setSubject(""); setMessage(""); }}
-              >
-                Cancel
-              </button>
-              <button className="rounded-xl px-6 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200" style={{ backgroundColor: "#e4e4e4" }}>
-                Send Email
-              </button>
-            </div>
-          </div>
-
-        </div>
-      </div>
-
-      {/* List filter portal */}
-      {listFilterOpen && listFilterRect && createPortal(
-        <div
-          ref={listFilterPortalRef}
-          style={{
-            position: "fixed",
-            top: listFilterRect.bottom + 6,
-            left: listFilterRect.right - 160,
-            zIndex: 9999,
-            backgroundColor: "white",
-            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
-          }}
-          className="min-w-[160px] rounded-lg p-2"
-        >
-          {([
-            ["last-month", "Last Month's"],
-            ["last-year", "Last Year's"],
-            ["all-time", "All Time"],
-          ] as ["last-month" | "last-year" | "all-time", string][]).map(([val, label]) => (
-            <button
-              key={val}
-              className={`w-full rounded px-3 py-2 text-left text-sm hover:bg-gray-50 ${listFilter === val ? "font-semibold text-blue-600" : "text-gray-700"}`}
-              onMouseDown={(e) => { e.preventDefault(); setListFilter(val); setListFilterOpen(false); }}
-            >
-              {label}
-            </button>
-          ))}
-        </div>,
-        document.body
-      )}
-    </div>
-  );
-}
-
-// ── Page ───────────────────────────────────────────────────────────────────
-
 const ContributorsPage = () => {
   const [searchQuery, setSearchQuery] = useState("");
   const [refreshToken, setRefreshToken] = useState(0);
-  const [activeTab, setActiveTab] = useState<"table" | "email">("table");
   const [sortBy, setSortBy] = useState<ContributorSortBy>("date-desc");
 
   const sortDropdown = useDropdown();
@@ -597,71 +49,49 @@ const ContributorsPage = () => {
   return (
     <DashboardTemplate>
       <div className="flex flex-col">
-        {/* Header */}
         <div className="mb-4 flex items-center justify-between">
           <h1 className="text-3xl font-bold">Contributors</h1>
-          {activeTab === "email" && (
-            <div className="w-56">
-              <SearchBar onSearch={() => {}} width="100%" placeholder="Search" />
-            </div>
-          )}
         </div>
 
-        {/* Tabs */}
-        <div className="mb-6 flex space-x-6 border-b">
-          {(["table", "email"] as const).map((tab) => (
-            <button
-              key={tab}
-              onClick={() => setActiveTab(tab)}
-              className={`pb-3 text-base capitalize transition-colors ${
-                activeTab === tab
-                  ? "border-b-2 border-black font-semibold text-black"
-                  : "text-gray-400 hover:text-gray-600"
-              }`}
+        <div className="mb-6 flex items-center gap-x-3">
+          <div className="flex-grow">
+            <SearchBar onSearch={setSearchQuery} width="100%" />
+          </div>
+
+          {/* Sort button */}
+          <div ref={sortDropdown.buttonRef}>
+            <Button
+              variant="secondary"
+              onClick={sortDropdown.toggle}
+              style={{ display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 0, color: buttonColor }}
             >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
+              <SwapVertIcon />
+              Sort
+              <KeyboardArrowDownIcon />
+            </Button>
+          </div>
+
+          <AddContributorModal onAdded={() => setRefreshToken((v) => v + 1)}>
+            <button
+              className="inline-flex items-center gap-1 rounded-md px-4 py-2 text-sm font-medium"
+              style={{ backgroundColor: "#3E6DA6", color: "white" }}
+            >
+              Add Contributor +
             </button>
-          ))}
+          </AddContributorModal>
+
+          <button className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50">
+            Export <LaunchIcon fontSize="small" />
+          </button>
         </div>
 
-        {activeTab === "table" && (
-          <>
-            <div className="mb-6 flex items-center gap-x-3">
-              <div className="w-[340px]">
-                <SearchBar onSearch={setSearchQuery} width="100%" />
-              </div>
-              <div className="flex-1" />
-              <AddContributorModal onAdded={() => setRefreshToken((v) => v + 1)}>
-                <button
-                  className="flex items-center gap-1 rounded-md px-4 py-2 text-sm font-medium"
-                  style={{ backgroundColor: "#3E6DA6", color: "white" }}
-                >
-                  Add Contributor +
-                </button>
-              </AddContributorModal>
-              <div ref={sortDropdown.buttonRef}>
-                <button
-                  onClick={sortDropdown.toggle}
-                  className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50"
-                >
-                  <FilterListIcon fontSize="small" />
-                  Filters
-                </button>
-              </div>
-              <button className="flex items-center gap-1 rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-600 hover:bg-gray-50">
-                Export <LaunchIcon fontSize="small" />
-              </button>
-            </div>
-            <ContributorsTable searchQuery={searchQuery} refreshToken={refreshToken} sortBy={sortBy} />
-          </>
-        )}
-
-        {activeTab === "email" && <EmailTab />}
+        <ContributorsTable searchQuery={searchQuery} refreshToken={refreshToken} sortBy={sortBy} />
       </div>
 
       {/* Sort portal */}
       {sortDropdown.open && sortDropdown.rect && createPortal(
         <div
+          onMouseDown={(e) => e.stopPropagation()}
           style={{
             position: "fixed",
             top: sortDropdown.rect.bottom + 8,

--- a/frontend/src/app/dashboard/page.tsx
+++ b/frontend/src/app/dashboard/page.tsx
@@ -1,115 +1,382 @@
 "use client";
 
 export const dynamic = "force-dynamic";
-import React, { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import api from "@/utils/api";
-import TransactionsTable from "@/components/molecules/TransactionsTable";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
-import BarGraph from "@/components/molecules/BarGraph";
 import ContributionsGraph from "@/components/molecules/ContributionsGraph";
+import BarGraph from "@/components/molecules/BarGraph";
+import { ArrowUpRight, Info } from "lucide-react";
 
-// fetch the logged-in user via /auth/login using session cookie
-// and replace the default org name with the organization name returned from the backend.
+interface TopContributor {
+  id: string;
+  name: string;
+  fundName: string;
+  amount: number;
+  date: string;
+}
+
+interface Transaction {
+  id: string;
+  amount: number;
+  date: string;
+  type: string;
+  contributor?: { id: string; firstName: string; lastName: string };
+  fund?: { id: string; name: string };
+}
+
+type ContributorsRange = "last-year" | "last-month" | "today";
+type ContributionRange = "last-month" | "last-year" | "all";
+
+
+function formatCurrency(amount: number) {
+  return new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency: "USD",
+  }).format(amount);
+}
+
+function downloadCSV(filename: string, rows: string[][]) {
+  const csv = rows
+    .map((r) => r.map((cell) => `"${String(cell).replace(/"/g, '""')}"`).join(","))
+    .join("\n");
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8;" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function ExportButton({ onClick }: { onClick?: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      className="inline-flex items-center gap-2 rounded-lg border border-[#3E6DA6]/40 bg-white px-3.5 py-1.5 text-sm text-[#3E6DA6] hover:bg-[#3E6DA6]/5"
+    >
+      <ArrowUpRight size={14} />
+      Export
+    </button>
+  );
+}
+
+function StatCard({
+  value,
+  label,
+  positive,
+}: {
+  value: string;
+  label: string;
+  positive?: boolean;
+}) {
+  return (
+    <div className="flex-1 rounded-2xl border border-gray-100 bg-white p-5 shadow-[0_1px_2px_rgba(0,0,0,0.04)]">
+      <div
+        className={`text-[26px] font-bold leading-tight ${positive ? "text-emerald-600" : "text-gray-900"}`}
+      >
+        {value}
+      </div>
+      <div className="mt-1.5 flex items-center gap-1 text-sm text-gray-400">
+        {label}
+        <Info size={12} className="text-gray-300" />
+      </div>
+    </div>
+  );
+}
+
 const DashboardPage = () => {
-  const [orgName, setOrgName] = useState<string>("Museum of the Sea");
+  const [allTransactions, setAllTransactions] = useState<Transaction[]>([]);
+  const [contributorsRange, setContributorsRange] =
+    useState<ContributorsRange>("last-month");
+  const [contributionRange, setContributionRange] =
+    useState<ContributionRange>("last-month");
+  const [activityRange, setActivityRange] = useState<"last-year" | "last-6m" | "today">("last-year");
+  const [activityStats, setActivityStats] = useState({
+    total: 0,
+    mostActive: "—",
+    leastActive: "—",
+    median: 0,
+    mean: 0,
+  });
 
   useEffect(() => {
-    const loadUser = async () => {
+    const loadData = async () => {
       try {
-        const res = await api.get("/auth/login");
-        const org = res.data.user?.organization?.name;
-        if (org) setOrgName(org);
+        const txRes = await api.get("/transactions");
+        const txList: Transaction[] = txRes.data.transactions ?? [];
+        setAllTransactions(txList);
+
+        // Activity stats
+        const byMonth: Record<string, number> = {};
+        txList.forEach((t) => {
+          const key = new Date(t.date).toLocaleString("default", {
+            month: "short",
+            year: "numeric",
+          });
+          byMonth[key] = (byMonth[key] ?? 0) + 1;
+        });
+        const entries = Object.entries(byMonth).sort((a, b) => b[1] - a[1]);
+        const counts = entries.map(([, v]) => v).sort((a, b) => a - b);
+        const median =
+          counts.length > 0 ? counts[Math.floor(counts.length / 2)] : 0;
+        const mean =
+          counts.length > 0
+            ? Math.round(counts.reduce((a, b) => a + b, 0) / counts.length)
+            : 0;
+
+        setActivityStats({
+          total: txList.length,
+          mostActive: entries[0]?.[0] ?? "—",
+          leastActive: entries[entries.length - 1]?.[0] ?? "—",
+          median,
+          mean,
+        });
       } catch (err) {
-        console.error("Error loading user", err);
+        console.error("Error loading dashboard data", err);
       }
     };
-    void loadUser();
+
+    void loadData();
   }, []);
+
+  const monthlyStats = useMemo(() => {
+    const now = new Date();
+    let cutoff: Date | null = new Date(now);
+    if (contributionRange === "last-month") {
+      cutoff.setMonth(now.getMonth() - 1);
+    } else if (contributionRange === "last-year") {
+      cutoff.setFullYear(now.getFullYear() - 1);
+    } else {
+      cutoff = null;
+    }
+
+    const inRange = allTransactions.filter((t) =>
+      cutoff ? new Date(t.date) >= cutoff : true,
+    );
+    const totalAll = allTransactions
+      .filter((t) => t.type === "DONATION" || t.type === "INVESTMENT")
+      .reduce((sum, t) => sum + t.amount, 0);
+    const earnings = inRange
+      .filter((t) => t.type === "INVESTMENT")
+      .reduce((sum, t) => sum + t.amount, 0);
+    const contributions = inRange
+      .filter((t) => t.type === "DONATION")
+      .reduce((sum, t) => sum + t.amount, 0);
+
+    return {
+      returnRate:
+        totalAll > 0
+          ? parseFloat(((earnings / totalAll) * 100).toFixed(2))
+          : 0,
+      earnings,
+      contributions,
+    };
+  }, [allTransactions, contributionRange]);
+
+  const statLabelPrefix =
+    contributionRange === "last-month"
+      ? new Date().toLocaleString("default", { month: "long" })
+      : contributionRange === "last-year"
+        ? "Year"
+        : "All-Time";
+
+  const topContributors = useMemo<TopContributor[]>(() => {
+    const now = new Date();
+    const cutoff = new Date(now);
+    if (contributorsRange === "last-year") {
+      cutoff.setFullYear(now.getFullYear() - 1);
+    } else if (contributorsRange === "last-month") {
+      cutoff.setMonth(now.getMonth() - 1);
+    } else {
+      cutoff.setHours(0, 0, 0, 0);
+    }
+
+    const map: Record<
+      string,
+      { name: string; fundName: string; amount: number; date: string }
+    > = {};
+    allTransactions
+      .filter(
+        (t) =>
+          t.type === "DONATION" &&
+          t.contributor &&
+          new Date(t.date) >= cutoff,
+      )
+      .forEach((t) => {
+        const id = t.contributor!.id;
+        const name = `${t.contributor!.firstName} ${t.contributor!.lastName}`;
+        const fundName = t.fund?.name ?? "Unknown Fund";
+        if (!map[id]) map[id] = { name, fundName, amount: 0, date: t.date };
+        map[id].amount += t.amount;
+      });
+    return Object.entries(map)
+      .map(([id, v]) => ({ id, ...v }))
+      .sort((a, b) => b.amount - a.amount)
+      .slice(0, 5);
+  }, [allTransactions, contributorsRange]);
 
   return (
     <DashboardTemplate>
-      <div className="mb-8 text-4xl font-bold">{orgName}</div>
-      <div className="flex items-center justify-between">
-        <div className="text-3xl font-medium">Contribution Total</div>
-        <button className="bg-gray-200 text-black hover:bg-gray-300 focus:ring-gray-300 dark:border-gray-300 mb-2 me-2 inline-flex items-center rounded-xl px-4 py-1.5 text-center text-lg font-light focus:outline-none focus:ring-2">
-          Export
-          <svg
-            className="text-black dark:text-white ml-2 h-5 w-5"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778"
-            />
-          </svg>
-        </button>
-      </div>
+      <div className="-m-8 min-h-[calc(100vh-0px)] p-8">
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-[32px] font-bold text-gray-900">Dashboard</h1>
+        </div>
 
-      {/* <div className="bg-gray-100 mt-4 h-96 w-auto rounded-3xl p-6">
-        Overall Contributions Graph
-      </div> */}
-      <ContributionsGraph />
+        {/* Your Total Contribution */}
+        <section className="mb-10">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-900">
+              Your Total Contribution
+            </h2>
+            <ExportButton onClick={() => {
+              const now = new Date();
+              let cutoff: Date | null = new Date(now);
+              if (contributionRange === "last-month") cutoff.setMonth(now.getMonth() - 1);
+              else if (contributionRange === "last-year") cutoff.setFullYear(now.getFullYear() - 1);
+              else cutoff = null;
+              const rows = allTransactions
+                .filter((t) => (t.type === "DONATION" || t.type === "INVESTMENT") && (cutoff ? new Date(t.date) >= cutoff : true))
+                .map((t) => [
+                  new Date(t.date).toLocaleDateString(),
+                  t.type,
+                  t.contributor ? `${t.contributor.firstName} ${t.contributor.lastName}` : "",
+                  t.fund?.name ?? "",
+                  t.amount.toFixed(2),
+                ]);
+              downloadCSV("total-contributions.csv", [["Date", "Type", "Contributor", "Fund", "Amount"], ...rows]);
+            }} />
+          </div>
+          <div className="grid grid-cols-3 gap-4">
+            <div className="col-span-2">
+              <ContributionsGraph
+                range={contributionRange}
+                onRangeChange={setContributionRange}
+              />
+            </div>
+            <div className="flex flex-col gap-4">
+              <StatCard
+                value={`+${monthlyStats.returnRate}%`}
+                label={`${statLabelPrefix} Return`}
+                positive
+              />
+              <StatCard
+                value={formatCurrency(monthlyStats.earnings)}
+                label={`${statLabelPrefix} Earnings`}
+              />
+              <StatCard
+                value={formatCurrency(monthlyStats.contributions)}
+                label={`${statLabelPrefix} Contributions`}
+              />
+            </div>
+          </div>
+        </section>
 
-      <div className="mb-4 mt-12 flex items-center justify-between">
-        <div className="text-3xl font-medium">Recent Contributions</div>
-        <button className="bg-gray-200 text-black hover:bg-gray-300 focus:ring-gray-300 dark:border-gray-300 mb-2 me-2 inline-flex items-center rounded-xl px-4 py-1.5 text-center text-lg font-light focus:outline-none focus:ring-2">
-          Export
-          <svg
-            className="text-black dark:text-white ml-2 h-5 w-5"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778"
-            />
-          </svg>
-        </button>
-      </div>
+        {/* Your Contributors */}
+        <section className="mb-10">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-900">
+              Your Contributors
+            </h2>
+            <ExportButton onClick={() => {
+              const rows = topContributors.map((c) => [c.name, c.fundName, c.amount.toFixed(2)]);
+              downloadCSV("top-contributors.csv", [["Name", "Fund", "Total Amount"], ...rows]);
+            }} />
+          </div>
+          <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
+            <div className="mb-5 flex items-center justify-between">
+              <span className="text-sm font-semibold text-gray-700">
+                Top Contributors
+              </span>
+              <div className="flex items-center gap-5 text-sm">
+                {(
+                  [
+                    ["last-year", "Last Year"],
+                    ["last-month", "Last Month"],
+                    ["today", "Today"],
+                  ] as [ContributorsRange, string][]
+                ).map(([val, label]) => (
+                  <button
+                    key={val}
+                    onClick={() => setContributorsRange(val)}
+                    className={
+                      contributorsRange === val
+                        ? "font-semibold text-gray-900"
+                        : "text-gray-400 hover:text-gray-600"
+                    }
+                  >
+                    {label}
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-4">
+              {topContributors.length === 0 ? (
+                <p className="text-sm text-gray-400">
+                  No contribution data for this range.
+                </p>
+              ) : (
+                topContributors.map((c) => (
+                  <div
+                    key={c.id}
+                    className="flex items-center justify-between"
+                  >
+                    <div>
+                      <div className="text-[15px] font-semibold text-gray-900">
+                        {c.name}
+                      </div>
+                      <div className="mt-0.5 text-xs text-gray-400">
+                        {c.fundName}
+                      </div>
+                    </div>
+                    <div className="text-sm font-semibold text-emerald-600">
+                      +
+                      {new Intl.NumberFormat("en-US", {
+                        minimumFractionDigits: 2,
+                        maximumFractionDigits: 2,
+                      }).format(c.amount)}
+                    </div>
+                  </div>
+                ))
+              )}
+            </div>
+          </div>
+        </section>
 
-      <TransactionsTable tableType="contributions" />
-
-      <div className="mt-12 flex items-center justify-between">
-        <div className="text-3xl font-medium">Activity Level</div>
-        <button className="bg-gray-200 text-black hover:bg-gray-300 focus:ring-gray-300 dark:border-gray-300 mb-2 me-2 inline-flex items-center rounded-xl px-4 py-1.5 text-center text-lg font-light focus:outline-none focus:ring-2">
-          Export
-          <svg
-            className="text-black dark:text-white ml-2 h-5 w-5"
-            aria-hidden="true"
-            xmlns="http://www.w3.org/2000/svg"
-            width="24"
-            height="24"
-            fill="none"
-            viewBox="0 0 24 24"
-          >
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M18 14v4.833A1.166 1.166 0 0 1 16.833 20H5.167A1.167 1.167 0 0 1 4 18.833V7.167A1.166 1.166 0 0 1 5.167 6h4.618m4.447-2H20v5.768m-7.889 2.121 7.778-7.778"
-            />
-          </svg>
-        </button>
-      </div>
-
-      <div className="bg-gray-100 mt-4 h-96 w-auto rounded-3xl p-6">
-        <BarGraph />
+        {/* Your Activity Level */}
+        <section className="pb-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-bold text-gray-900">
+              Your Activity Level
+            </h2>
+            <ExportButton onClick={() => {
+              const now = new Date();
+              const cutoff = new Date(now);
+              if (activityRange === "last-year") cutoff.setFullYear(now.getFullYear() - 1);
+              else if (activityRange === "last-6m") cutoff.setMonth(now.getMonth() - 5);
+              else cutoff.setHours(0, 0, 0, 0);
+              const byMonth: Record<string, { donations: number; investments: number }> = {};
+              allTransactions
+                .filter((t) => new Date(t.date) >= cutoff)
+                .forEach((t) => {
+                  const key = new Date(t.date).toLocaleString("default", { month: "long", year: "numeric" });
+                  if (!byMonth[key]) byMonth[key] = { donations: 0, investments: 0 };
+                  if (t.type === "DONATION") byMonth[key].donations += 1;
+                  else if (t.type === "INVESTMENT") byMonth[key].investments += 1;
+                });
+              const rows = Object.entries(byMonth).map(([month, v]) => [month, v.donations.toString(), v.investments.toString()]);
+              downloadCSV("activity-level.csv", [["Month", "Donations", "Investments"], ...rows]);
+            }} />
+          </div>
+          <BarGraph range={activityRange} onRangeChange={setActivityRange} />
+          <div className="mt-4 grid grid-cols-4 gap-4">
+            <StatCard value={activityStats.mostActive} label="Most Active" />
+            <StatCard value={activityStats.leastActive} label="Least Active" />
+            <StatCard value={activityStats.median.toString()} label="Median / month" />
+            <StatCard value={activityStats.mean.toString()} label="Mean / month" />
+          </div>
+        </section>
       </div>
     </DashboardTemplate>
   );

--- a/frontend/src/app/funds/[fundId]/page.tsx
+++ b/frontend/src/app/funds/[fundId]/page.tsx
@@ -2,12 +2,10 @@
 
 export const dynamic = "force-dynamic";
 
-import React, { useEffect, useState, useMemo, use } from "react";
+import React, { useEffect, useState, use } from "react";
 import FundTemplate from "@/components/templates/FundTemplate";
 import ContributionsGraph from "@/components/molecules/ContributionsGraph";
 import TransactionsTable from "@/components/molecules/TransactionsTable";
-import AddTransactionModal from "@/components/molecules/AddTransactionModal";
-import AddContributorModal from "@/components/molecules/AddContributorModal";
 import api from "@/utils/api";
 
 interface FundData {
@@ -33,7 +31,7 @@ interface Contributor {
 
 const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
   const { fundId } = use(params);
-  const [activeTab, setActiveTab] = useState<"summary" | "contributors">("summary");
+  const [activeTab, setActiveTab] = useState<"summary" | "contributors" | "settings">("summary");
 
   const [fundData, setFundData] = useState<FundData | null>(null);
   const [loading, setLoading] = useState(true);
@@ -41,8 +39,17 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
   const [contributorsData, setContributors] = useState<Contributor[]>([]);
   const [oneYearEarnings, setOneYearEarnings] = useState<number>(0);
   const [contributorTotals, setContributorTotals] = useState<Record<string, number>>({});
-  const [contributorSearch, setContributorSearch] = useState("");
-  const [contributorRefresh, setContributorRefresh] = useState(0);
+  const [settingsForm, setSettingsForm] = useState<{
+    name: string;
+    description: string;
+    type: "ENDOWMENT" | "DONATION";
+    restriction: boolean;
+    purpose: string;
+    rate: string;
+  } | null>(null);
+  const [settingsSaving, setSettingsSaving] = useState(false);
+  const [settingsError, setSettingsError] = useState<string | null>(null);
+  const [settingsSuccess, setSettingsSuccess] = useState(false);
 
   useEffect(() => {
     const fetchFund = async () => {
@@ -89,15 +96,47 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
     };
 
     fetchFund();
-  }, [fundId, contributorRefresh]);
+  }, [fundId]);
 
-  const filteredContributors = useMemo(() => {
-    const q = contributorSearch.trim().toLowerCase();
-    if (!q) return contributorsData;
-    return contributorsData.filter((c) =>
-      `${c.firstName} ${c.lastName}`.toLowerCase().includes(q)
-    );
-  }, [contributorsData, contributorSearch]);
+  // Sync settings form when fund data loads
+  useEffect(() => {
+    if (!fundData) return;
+    setSettingsForm({
+      name: fundData.name,
+      description: fundData.description,
+      type: fundData.type,
+      restriction: fundData.restriction ?? false,
+      purpose: fundData.purpose ?? "",
+      rate: fundData.units && fundData.amount ? String((fundData.amount / fundData.units).toFixed(4)) : "",
+    });
+  }, [fundData]);
+
+  const handleSettingsSave = async () => {
+    if (!settingsForm) return;
+    setSettingsSaving(true);
+    setSettingsError(null);
+    setSettingsSuccess(false);
+    try {
+      const payload: Record<string, any> = {
+        name: settingsForm.name.trim(),
+        description: settingsForm.description.trim(),
+        type: settingsForm.type,
+        restriction: settingsForm.restriction,
+        purpose: settingsForm.restriction ? settingsForm.purpose.trim() : null,
+        rate: settingsForm.rate !== "" ? parseFloat(settingsForm.rate) : null,
+      };
+      const res = await api.put(`/funds/${fundId}`, payload);
+      setFundData((prev) => prev ? { ...prev, ...res.data } : prev);
+      setSettingsSuccess(true);
+      setTimeout(() => setSettingsSuccess(false), 3000);
+    } catch (err) {
+      setSettingsError(err instanceof Error ? err.message : "Failed to save");
+    } finally {
+      setSettingsSaving(false);
+    }
+  };
+
+  const filteredContributors = contributorsData;
 
   if (loading) return <div>loading fund data</div>;
   if (error) return <div>error: {error}</div>;
@@ -107,14 +146,6 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
     <div className="space-y-8">
       {/* Graph card */}
       <div className="rounded-xl border px-6 py-4 shadow-sm">
-        <div className="mb-4 flex items-center justify-between">
-          <div>
-            <div className="text-gray-500 text-sm">Account Balance</div>
-            <div className="text-3xl font-bold">
-              ${fundData.amount.toLocaleString()}
-            </div>
-          </div>
-        </div>
         <ContributionsGraph fundId={fundId} />
         <div className="text-gray-700 mt-4 flex gap-12 text-sm">
           <div>
@@ -143,17 +174,7 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
 
       {/* Transactions below graph */}
       <div>
-        <div className="mb-4 flex items-center justify-between">
-          <h2 className="text-2xl font-bold">All transactions</h2>
-          <AddTransactionModal>
-            <button
-              className="flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-              style={{ backgroundColor: "#3E6DA6", color: "white" }}
-            >
-              + Add a new transaction
-            </button>
-          </AddTransactionModal>
-        </div>
+        <h2 className="mb-4 text-2xl font-bold">All transactions</h2>
         <TransactionsTable
           tableType="transactions"
           fundId={fundId}
@@ -168,34 +189,12 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
       {/* Header */}
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold">All Contributors</h2>
-        <AddContributorModal onAdded={() => setContributorRefresh((r) => r + 1)}>
-          <button
-            className="flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
-            style={{ backgroundColor: "#3E6DA6", color: "white" }}
-          >
-            + Add new contributor
-          </button>
-        </AddContributorModal>
-      </div>
-
-      {/* Search */}
-      <div className="flex items-center gap-2 rounded-md border px-3 py-2">
-        <svg className="text-gray-400 h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
-        </svg>
-        <input
-          type="text"
-          placeholder="Search"
-          value={contributorSearch}
-          onChange={(e) => setContributorSearch(e.target.value)}
-          className="w-full text-sm outline-none"
-        />
       </div>
 
       {/* Table */}
       <div>
         <div className="mb-2 flex justify-between px-2 text-sm font-semibold">
-          <span>Date</span>
+          <span>Name</span>
           <span>Total contributions</span>
         </div>
         <div className="divide-y">
@@ -218,6 +217,120 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
     </div>
   );
 
+  const settings = settingsForm ? (
+    <div className="max-w-xl space-y-6">
+      <h2 className="text-xl font-bold">Fund Settings</h2>
+
+      {/* Name */}
+      <div>
+        <label className="mb-1.5 block text-sm font-semibold text-gray-700">Fund Name</label>
+        <input
+          type="text"
+          value={settingsForm.name}
+          onChange={(e) => setSettingsForm((f) => f && { ...f, name: e.target.value })}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-400"
+        />
+      </div>
+
+      {/* Description */}
+      <div>
+        <label className="mb-1.5 block text-sm font-semibold text-gray-700">Description</label>
+        <textarea
+          value={settingsForm.description}
+          onChange={(e) => setSettingsForm((f) => f && { ...f, description: e.target.value })}
+          rows={3}
+          className="w-full resize-none rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-400"
+        />
+      </div>
+
+      {/* Type */}
+      <div>
+        <label className="mb-1.5 block text-sm font-semibold text-gray-700">Fund Type</label>
+        <select
+          value={settingsForm.type}
+          onChange={(e) => setSettingsForm((f) => f && { ...f, type: e.target.value as "ENDOWMENT" | "DONATION" })}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-400"
+        >
+          <option value="ENDOWMENT">Endowment</option>
+          <option value="DONATION">Donation</option>
+        </select>
+      </div>
+
+      {/* Restriction */}
+      <div>
+        <label className="mb-1.5 block text-sm font-semibold text-gray-700">Restriction</label>
+        <div className="flex gap-4">
+          {[{ label: "Restricted", value: true }, { label: "Unrestricted", value: false }].map(({ label, value }) => (
+            <label key={label} className="flex cursor-pointer items-center gap-2 text-sm">
+              <input
+                type="radio"
+                checked={settingsForm.restriction === value}
+                onChange={() => setSettingsForm((f) => f && { ...f, restriction: value })}
+              />
+              {label}
+            </label>
+          ))}
+        </div>
+      </div>
+
+      {/* Purpose — only if restricted */}
+      {settingsForm.restriction && (
+        <div>
+          <label className="mb-1.5 block text-sm font-semibold text-gray-700">Purpose</label>
+          <input
+            type="text"
+            value={settingsForm.purpose}
+            onChange={(e) => setSettingsForm((f) => f && { ...f, purpose: e.target.value })}
+            className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-400"
+          />
+        </div>
+      )}
+
+      {/* Unit rate */}
+      <div>
+        <label className="mb-1.5 block text-sm font-semibold text-gray-700">Unit Rate ($ per unit)</label>
+        <input
+          type="number"
+          min="0"
+          step="0.0001"
+          placeholder="Leave blank for non-unitized"
+          value={settingsForm.rate}
+          onChange={(e) => setSettingsForm((f) => f && { ...f, rate: e.target.value })}
+          className="w-full rounded-lg border border-gray-300 px-3 py-2.5 text-sm outline-none focus:border-gray-400"
+        />
+      </div>
+
+      {/* Feedback */}
+      {settingsError && <p className="text-sm text-red-500">{settingsError}</p>}
+      {settingsSuccess && <p className="text-sm text-green-600">Changes saved.</p>}
+
+      {/* Actions */}
+      <div className="flex gap-3 pt-2">
+        <button
+          onClick={handleSettingsSave}
+          disabled={settingsSaving}
+          className="rounded-lg px-6 py-2 text-sm font-medium text-white disabled:opacity-60"
+          style={{ backgroundColor: "#3E6DA6" }}
+        >
+          {settingsSaving ? "Saving…" : "Save Changes"}
+        </button>
+        <button
+          onClick={() => setSettingsForm({
+            name: fundData.name,
+            description: fundData.description,
+            type: fundData.type,
+            restriction: fundData.restriction ?? false,
+            purpose: fundData.purpose ?? "",
+            rate: fundData.units && fundData.amount ? String((fundData.amount / fundData.units).toFixed(4)) : "",
+          })}
+          className="rounded-lg border border-gray-300 px-5 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Discard
+        </button>
+      </div>
+    </div>
+  ) : null;
+
   return (
     <FundTemplate
       fundName={fundData.name}
@@ -225,6 +338,7 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
       fundType={fundData.type === "ENDOWMENT" ? "Endowment" : "Donation"}
       summary={summary}
       contributors={contributors}
+      settings={settings}
       activeTab={activeTab}
       onTabChange={setActiveTab}
     />

--- a/frontend/src/app/funds/[fundId]/page.tsx
+++ b/frontend/src/app/funds/[fundId]/page.tsx
@@ -1,8 +1,13 @@
 "use client";
-import React, { useEffect, useState, use } from "react";
+
+export const dynamic = "force-dynamic";
+
+import React, { useEffect, useState, useMemo, use } from "react";
 import FundTemplate from "@/components/templates/FundTemplate";
 import ContributionsGraph from "@/components/molecules/ContributionsGraph";
 import TransactionsTable from "@/components/molecules/TransactionsTable";
+import AddTransactionModal from "@/components/molecules/AddTransactionModal";
+import AddContributorModal from "@/components/molecules/AddContributorModal";
 import api from "@/utils/api";
 
 interface FundData {
@@ -28,30 +33,54 @@ interface Contributor {
 
 const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
   const { fundId } = use(params);
-  const [activeTab, setActiveTab] = useState<
-    "summary" | "transactions" | "contributors"
-  >("summary");
+  const [activeTab, setActiveTab] = useState<"summary" | "contributors">("summary");
 
   const [fundData, setFundData] = useState<FundData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [contributorsData, setContributors] = useState<Contributor[]>([]);
+  const [oneYearEarnings, setOneYearEarnings] = useState<number>(0);
+  const [contributorTotals, setContributorTotals] = useState<Record<string, number>>({});
+  const [contributorSearch, setContributorSearch] = useState("");
+  const [contributorRefresh, setContributorRefresh] = useState(0);
 
   useEffect(() => {
     const fetchFund = async () => {
       try {
         setLoading(true);
-        const [fundResponse, contributorsResponse] = await Promise.all([
+        const oneYearAgo = new Date();
+        oneYearAgo.setFullYear(oneYearAgo.getFullYear() - 1);
+
+        const [fundResponse, contributorsResponse, txResponse] = await Promise.all([
           api.get(`/funds/${fundId}`),
           api.get(`/funds/${fundId}/contributors`),
+          api.get(`/funds/${fundId}/transactions`),
         ]);
-    
-        const fundData = fundResponse.data;
-        const contributorsData = contributorsResponse.data;
-        
-        setFundData(fundData);
-        setContributors(contributorsData.contributors || []);
 
+        setFundData(fundResponse.data);
+        setContributors(contributorsResponse.data.contributors || []);
+
+        const txList: any[] = txResponse.data.transactions || [];
+
+        // 1-year earnings
+        const earnings = txList
+          .filter((t) =>
+            (t.type === "DONATION" || t.type === "INVESTMENT") &&
+            new Date(t.date) >= oneYearAgo
+          )
+          .reduce((sum, t) => sum + t.amount, 0);
+        setOneYearEarnings(earnings);
+
+        // total contributions per contributor for this fund
+        const totals: Record<string, number> = {};
+        txList
+          .filter((t) => t.type === "DONATION" || t.type === "INVESTMENT")
+          .forEach((t) => {
+            if (t.contributorId) {
+              totals[t.contributorId] = (totals[t.contributorId] || 0) + t.amount;
+            }
+          });
+        setContributorTotals(totals);
       } catch (err) {
         setError(err instanceof Error ? err.message : "unknown error");
       } finally {
@@ -60,15 +89,23 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
     };
 
     fetchFund();
-  }, [fundId]);
+  }, [fundId, contributorRefresh]);
+
+  const filteredContributors = useMemo(() => {
+    const q = contributorSearch.trim().toLowerCase();
+    if (!q) return contributorsData;
+    return contributorsData.filter((c) =>
+      `${c.firstName} ${c.lastName}`.toLowerCase().includes(q)
+    );
+  }, [contributorsData, contributorSearch]);
 
   if (loading) return <div>loading fund data</div>;
   if (error) return <div>error: {error}</div>;
   if (!fundData) return <div>error: fund not found</div>;
 
-  // Summary tab content
   const summary = (
     <div className="space-y-8">
+      {/* Graph card */}
       <div className="rounded-xl border px-6 py-4 shadow-sm">
         <div className="mb-4 flex items-center justify-between">
           <div>
@@ -77,61 +114,106 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
               ${fundData.amount.toLocaleString()}
             </div>
           </div>
-          {/* Static date range for now */}
-          <div className="text-gray-600 text-sm">{fundData.createdAt}</div>
         </div>
-        <ContributionsGraph />
+        <ContributionsGraph fundId={fundId} />
         <div className="text-gray-700 mt-4 flex gap-12 text-sm">
           <div>
-            <div className="text-green-600 text-lg font-semibold">+3.21%</div>
-            <div className="text-xs">1-Year Return</div>
+            {(() => {
+              const startBalance = fundData.amount - oneYearEarnings;
+              const base = startBalance > 0 ? startBalance : (fundData.amount > 0 ? fundData.amount : null);
+              const pct = base !== null && oneYearEarnings !== 0 ? (oneYearEarnings / base) * 100 : null;
+              return (
+                <>
+                  <div className={`text-lg font-semibold ${pct !== null && pct >= 0 ? "text-green-600" : "text-red-500"}`}>
+                    {pct !== null ? `${pct >= 0 ? "+" : ""}${pct.toFixed(2)}%` : "—"}
+                  </div>
+                  <div className="text-xs">1-Year Return</div>
+                </>
+              );
+            })()}
           </div>
           <div>
-            <div className="text-lg font-semibold">$18,344</div>
+            <div className="text-lg font-semibold">
+              ${oneYearEarnings.toLocaleString()}
+            </div>
             <div className="text-xs">1-Year Earnings</div>
           </div>
         </div>
       </div>
-    </div>
-  );
 
-  // Transactions tab content
-  const transactions = (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <h2 className="text-2xl font-medium">All transactions</h2>
-        <button className="bg-blue-600 text-white hover:bg-blue-700 rounded-md px-4 py-2 text-sm">
-          + Add a new transaction
-        </button>
+      {/* Transactions below graph */}
+      <div>
+        <div className="mb-4 flex items-center justify-between">
+          <h2 className="text-2xl font-bold">All transactions</h2>
+          <AddTransactionModal>
+            <button
+              className="flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
+              style={{ backgroundColor: "#3E6DA6", color: "white" }}
+            >
+              + Add a new transaction
+            </button>
+          </AddTransactionModal>
+        </div>
+        <TransactionsTable
+          tableType="transactions"
+          fundId={fundId}
+          fundName={fundData.name}
+        />
       </div>
-      <TransactionsTable
-        tableType="transactions"
-        fundId={fundId}
-        fundName={fundData.name}
-      />
     </div>
   );
 
-  // Contributors tab content
   const contributors = (
     <div className="space-y-4">
-      <input
-        type="text"
-        placeholder="Search"
-        className="w-full rounded-md border px-4 py-2 text-sm"
-      />
-      <div className="space-y-2">
-        {contributorsData.map((contributor) => (
-          <div
-            key={contributor.id}
-            className="text-gray-800 flex justify-between border-b pb-2 text-sm"
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-2xl font-bold">All Contributors</h2>
+        <AddContributorModal onAdded={() => setContributorRefresh((r) => r + 1)}>
+          <button
+            className="flex items-center gap-2 rounded-md px-4 py-2 text-sm font-medium"
+            style={{ backgroundColor: "#3E6DA6", color: "white" }}
           >
-            <span>
-              {contributor.firstName} {contributor.lastName}
-            </span>
-            <span className="font-medium">{contributor.email || "N/A"}</span>
-          </div>
-        ))}
+            + Add new contributor
+          </button>
+        </AddContributorModal>
+      </div>
+
+      {/* Search */}
+      <div className="flex items-center gap-2 rounded-md border px-3 py-2">
+        <svg className="text-gray-400 h-4 w-4 shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+        </svg>
+        <input
+          type="text"
+          placeholder="Search"
+          value={contributorSearch}
+          onChange={(e) => setContributorSearch(e.target.value)}
+          className="w-full text-sm outline-none"
+        />
+      </div>
+
+      {/* Table */}
+      <div>
+        <div className="mb-2 flex justify-between px-2 text-sm font-semibold">
+          <span>Date</span>
+          <span>Total contributions</span>
+        </div>
+        <div className="divide-y">
+          {filteredContributors.length === 0 ? (
+            <div className="text-gray-400 py-6 text-center text-sm">No contributors found</div>
+          ) : (
+            filteredContributors.map((contributor) => (
+              <div key={contributor.id} className="flex items-center justify-between px-2 py-3 text-sm">
+                <span className="font-medium">{contributor.firstName} {contributor.lastName}</span>
+                <span className="text-gray-700">
+                  {contributorTotals[contributor.id] != null
+                    ? `$${contributorTotals[contributor.id].toLocaleString("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+                    : "—"}
+                </span>
+              </div>
+            ))
+          )}
+        </div>
       </div>
     </div>
   );
@@ -140,8 +222,8 @@ const FundPage = ({ params }: { params: Promise<{ fundId: string }> }) => {
     <FundTemplate
       fundName={fundData.name}
       fundDescription={fundData.description}
+      fundType={fundData.type === "ENDOWMENT" ? "Endowment" : "Donation"}
       summary={summary}
-      transactions={transactions}
       contributors={contributors}
       activeTab={activeTab}
       onTabChange={setActiveTab}

--- a/frontend/src/app/funds/page.tsx
+++ b/frontend/src/app/funds/page.tsx
@@ -74,7 +74,7 @@ const FundsPage = () => {
     <DashboardTemplate>
       <div className="flex flex-col justify-items-center">
         <div className="mb-6 flex items-center justify-between">
-          <h1 className="text-3xl">All Funds</h1>
+          <h1 className="text-3xl font-bold">Funds</h1>
           <div className="flex gap-x-4">
 <AddFundModal>
               <Button
@@ -145,6 +145,7 @@ const FundsPage = () => {
       {/* Filter portal */}
       {filterDropdown.open && filterDropdown.rect && createPortal(
         <div
+          onMouseDown={(e) => e.stopPropagation()}
           style={{
             position: "fixed",
             top: filterDropdown.rect.bottom + 8,
@@ -188,6 +189,7 @@ const FundsPage = () => {
       {/* Sort portal */}
       {sortDropdown.open && sortDropdown.rect && createPortal(
         <div
+          onMouseDown={(e) => e.stopPropagation()}
           style={{
             position: "fixed",
             top: sortDropdown.rect.bottom + 8,

--- a/frontend/src/app/funds/page.tsx
+++ b/frontend/src/app/funds/page.tsx
@@ -2,14 +2,14 @@
 
 export const dynamic = "force-dynamic";
 
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import * as React from "react";
+import { createPortal } from "react-dom";
 import DashboardTemplate from "@/components/templates/DashboardTemplate";
 import FundsListTable from "@/components/molecules/FundsListTable";
 import FundsCardTable from "@/components/molecules/FundsCardTable";
 import FilterAltIcon from "@mui/icons-material/FilterAlt";
 import SwapVertIcon from "@mui/icons-material/SwapVert";
-import SettingsIcon from "@mui/icons-material/Settings";
 import KeyboardArrowDownIcon from "@mui/icons-material/KeyboardArrowDown";
 import ViewModuleIcon from "@mui/icons-material/ViewModule";
 import ViewListIcon from "@mui/icons-material/ViewList";
@@ -17,28 +17,58 @@ import ToggleButton from "@mui/material/ToggleButton";
 import ToggleButtonGroup from "@mui/material/ToggleButtonGroup";
 import Button from "@/components/atoms/Button";
 import SearchBar from "@/components/molecules/Searchbar";
-// import ContributionsGraph from "@/components/molecules/ContributionsGraph";
 import AddFundModal from "@/components/molecules/AddFundModal";
+
+export type FundSortBy = "name-asc" | "name-desc" | "amount-asc" | "amount-desc" | "newest" | "oldest";
+export type FundFilterType = "all" | "Endowment" | "Donation";
+export type FundFilterRestriction = "all" | "Restricted" | "Unrestricted";
+
+function useDropdown() {
+  const [open, setOpen] = useState(false);
+  const [rect, setRect] = useState<DOMRect | null>(null);
+  const buttonRef = useRef<HTMLDivElement>(null);
+
+  const toggle = () => {
+    if (!open && buttonRef.current) {
+      setRect(buttonRef.current.getBoundingClientRect());
+    }
+    setOpen((o) => !o);
+  };
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (buttonRef.current && !buttonRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return { open, setOpen, toggle, rect, buttonRef };
+}
 
 const FundsPage = () => {
   const buttonColor = "#838383";
   const [searchQuery, setSearchQuery] = useState("");
-
-  const handleSearch = (query: string) => {
-    console.log("Searching for:", query);
-    setSearchQuery(query);
-  };
-
   const [viewMode, setViewMode] = useState<"list" | "grid">("list");
 
-  const handleChange = (
-    event: React.MouseEvent<HTMLElement>,
+  const [filterType, setFilterType] = useState<FundFilterType>("all");
+  const [filterRestriction, setFilterRestriction] = useState<FundFilterRestriction>("all");
+  const [sortBy, setSortBy] = useState<FundSortBy>("newest");
+
+  const filterDropdown = useDropdown();
+  const sortDropdown = useDropdown();
+
+  const handleViewChange = (
+    _event: React.MouseEvent<HTMLElement>,
     newView: "list" | "grid" | null
   ) => {
-    if (newView !== null) {
-      setViewMode(newView);
-    }
+    if (newView !== null) setViewMode(newView);
   };
+
+  const filterActive = filterType !== "all" || filterRestriction !== "all";
 
   return (
     <DashboardTemplate>
@@ -46,31 +76,10 @@ const FundsPage = () => {
         <div className="mb-6 flex items-center justify-between">
           <h1 className="text-3xl">All Funds</h1>
           <div className="flex gap-x-4">
-            <Button
-              variant="borderless"
-              style={{
-                display: "flex",
-                alignItems: "center",
-                height: "40px",
-                padding: "0 16px",
-                marginBottom: 0,
-                color: buttonColor,
-              }}
-            >
-              <SettingsIcon fontSize="small" style={{ marginRight: 6 }} />
-              Settings
-            </Button>
-            <AddFundModal>
+<AddFundModal>
               <Button
                 variant="secondary"
-                style={{
-                  display: "flex",
-                  alignItems: "center",
-                  height: "40px",
-                  padding: "0 16px",
-                  marginBottom: 0,
-                  color: "#418EC8",
-                }}
+                style={{ display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 0, color: "#418EC8" }}
               >
                 Create new fund
                 <KeyboardArrowDownIcon />
@@ -81,66 +90,137 @@ const FundsPage = () => {
 
         <div className="mb-12 flex items-center justify-center gap-x-4">
           <div className="flex-grow">
-            <SearchBar
-              onSearch={handleSearch}
-              width="100%"
-              placeholder="Search for a fund..."
-            />
+            <SearchBar onSearch={setSearchQuery} width="100%" placeholder="Search for a fund..." />
           </div>
 
-          <Button
-            variant="secondary"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              height: "40px",
-              padding: "0 16px",
-              marginBottom: 0,
-              color: buttonColor,
-            }}
-          >
-            <FilterAltIcon style={{ marginRight: "6px" }} />
-            Filter tags
-          </Button>
+          {/* Filter button */}
+          <div ref={filterDropdown.buttonRef}>
+            <Button
+              variant="secondary"
+              onClick={filterDropdown.toggle}
+              style={{
+                display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 0,
+                color: filterActive ? "#3E6DA6" : buttonColor,
+                fontWeight: filterActive ? 600 : undefined,
+              }}
+            >
+              <FilterAltIcon style={{ marginRight: "6px" }} />
+              Filter{filterActive ? " •" : ""}
+            </Button>
+          </div>
 
-          <Button
-            variant="secondary"
-            style={{
-              display: "flex",
-              alignItems: "center",
-              height: "40px",
-              padding: "0 16px",
-              marginBottom: 0,
-              color: buttonColor,
-            }}
-          >
-            <SwapVertIcon />
-            Sort
-            <KeyboardArrowDownIcon />
-          </Button>
+          {/* Sort button */}
+          <div ref={sortDropdown.buttonRef}>
+            <Button
+              variant="secondary"
+              onClick={sortDropdown.toggle}
+              style={{ display: "flex", alignItems: "center", height: "40px", padding: "0 16px", marginBottom: 0, color: buttonColor }}
+            >
+              <SwapVertIcon />
+              Sort
+              <KeyboardArrowDownIcon />
+            </Button>
+          </div>
 
           <ToggleButtonGroup
             size="small"
             color="primary"
             value={viewMode}
             exclusive
-            onChange={handleChange}
+            onChange={handleViewChange}
             aria-label="View Mode"
           >
-            <ToggleButton value="grid" aria-label="grid view">
-              <ViewModuleIcon />
-            </ToggleButton>
-            <ToggleButton value="list" aria-label="list view">
-              <ViewListIcon />
-            </ToggleButton>
+            <ToggleButton value="grid" aria-label="grid view"><ViewModuleIcon /></ToggleButton>
+            <ToggleButton value="list" aria-label="list view"><ViewListIcon /></ToggleButton>
           </ToggleButtonGroup>
         </div>
+
         {viewMode === "list" ? (
-          <FundsListTable searchQuery={searchQuery} />
+          <FundsListTable searchQuery={searchQuery} filterType={filterType} filterRestriction={filterRestriction} sortBy={sortBy} />
         ) : (
-          <FundsCardTable searchQuery={searchQuery} />
+          <FundsCardTable searchQuery={searchQuery} filterType={filterType} filterRestriction={filterRestriction} sortBy={sortBy} />
         )}
       </div>
+
+      {/* Filter portal */}
+      {filterDropdown.open && filterDropdown.rect && createPortal(
+        <div
+          style={{
+            position: "fixed",
+            top: filterDropdown.rect.bottom + 8,
+            left: filterDropdown.rect.right - 200,
+            zIndex: 9999,
+            backgroundColor: "white",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+          }}
+          className="min-w-[200px] rounded-lg p-4"
+        >
+          <div className="mb-3">
+            <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Type</p>
+            {(["all", "Endowment", "Donation"] as FundFilterType[]).map((v) => (
+              <label key={v} className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+                <input type="radio" name="filterType" checked={filterType === v} onChange={() => setFilterType(v)} />
+                {v === "all" ? "All types" : v}
+              </label>
+            ))}
+          </div>
+          <div>
+            <p className="mb-1 text-xs font-semibold uppercase text-gray-500">Restriction</p>
+            {(["all", "Restricted", "Unrestricted"] as FundFilterRestriction[]).map((v) => (
+              <label key={v} className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+                <input type="radio" name="filterRestriction" checked={filterRestriction === v} onChange={() => setFilterRestriction(v)} />
+                {v === "all" ? "All restrictions" : v}
+              </label>
+            ))}
+          </div>
+          {filterActive && (
+            <button
+              className="mt-3 text-xs text-blue-500 underline"
+              onClick={() => { setFilterType("all"); setFilterRestriction("all"); }}
+            >
+              Clear filters
+            </button>
+          )}
+        </div>,
+        document.body
+      )}
+
+      {/* Sort portal */}
+      {sortDropdown.open && sortDropdown.rect && createPortal(
+        <div
+          style={{
+            position: "fixed",
+            top: sortDropdown.rect.bottom + 8,
+            left: sortDropdown.rect.right - 180,
+            zIndex: 9999,
+            backgroundColor: "white",
+            boxShadow: "0 4px 24px rgba(0,0,0,0.18)",
+          }}
+          className="min-w-[180px] rounded-lg p-4"
+        >
+          {(
+            [
+              ["newest", "Newest first"],
+              ["oldest", "Oldest first"],
+              ["name-asc", "Name A → Z"],
+              ["name-desc", "Name Z → A"],
+              ["amount-desc", "Amount: high to low"],
+              ["amount-asc", "Amount: low to high"],
+            ] as [FundSortBy, string][]
+          ).map(([value, label]) => (
+            <label key={value} className="flex cursor-pointer items-center gap-2 py-1 text-sm">
+              <input
+                type="radio"
+                name="sortBy"
+                checked={sortBy === value}
+                onChange={() => { setSortBy(value); sortDropdown.setOpen(false); }}
+              />
+              {label}
+            </label>
+          ))}
+        </div>,
+        document.body
+      )}
     </DashboardTemplate>
   );
 };

--- a/frontend/src/components/molecules/AddFundModal.tsx
+++ b/frontend/src/components/molecules/AddFundModal.tsx
@@ -1,17 +1,13 @@
 "use client";
 
 import React, { ReactNode, useState, useEffect } from "react";
-import Input from "@/components/atoms/Input";
-import Button from "@/components/atoms/Button";
-import { ScrollArea } from "@/components/ui/scroll";
 import {
   Dialog,
   DialogContent,
-  DialogFooter,
-  DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
+import * as VisuallyHidden from "@radix-ui/react-visually-hidden";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Label } from "@/components/ui/label";
 import api from "@/utils/api";
@@ -22,6 +18,12 @@ const AddFundModal: React.FC<AddFundModalProps> = ({ children }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [userOrgId, setUserOrgId] = useState<string | null>(null);
   const [name, setName] = useState("");
+  const [type, setType] = useState<"donation" | "endowment">("donation");
+  const [restriction, setRestriction] = useState<"restricted" | "unrestricted">("restricted");
+  const [description, setDescription] = useState("");
+  const [purpose, setPurpose] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   useEffect(() => {
     api.get("/auth/login").then((res) => {
@@ -30,30 +32,18 @@ const AddFundModal: React.FC<AddFundModalProps> = ({ children }) => {
       if (orgId) setUserOrgId(orgId);
     }).catch((err) => console.error("Failed to load user org", err));
   }, []);
-  const [type, setType] = useState<"donation" | "endowment">("donation");
-  const [restriction, setRestriction] = useState<"restricted" | "unrestricted">(
-    "restricted"
-  );
-  const [description, setDescription] = useState("");
-  const [purpose, setPurpose] = useState(""); // NEW
-  const [submitting, setSubmitting] = useState(false);
-  const [errorMsg, setErrorMsg] = useState<string | null>(null);
 
   const handleCancel = () => {
     setIsOpen(false);
     setErrorMsg(null);
     setSubmitting(false);
-    // optional: reset fields on cancel
-    // setName(""); setType("donation"); setRestriction("restricted"); setDescription(""); setPurpose("");
   };
 
-  const isRestrictedEndowment =
-    type === "endowment" && restriction === "restricted";
+  const isRestrictedEndowment = type === "endowment" && restriction === "restricted";
 
   const handleAdd = async () => {
     setErrorMsg(null);
 
-    // Frontend required-field checks
     if (!name.trim()) return setErrorMsg("Name is required.");
     if (!type) return setErrorMsg("Type is required.");
     if (isRestrictedEndowment && !purpose.trim())
@@ -69,7 +59,7 @@ const AddFundModal: React.FC<AddFundModalProps> = ({ children }) => {
       units: number;
     } = {
       name: name.trim(),
-      type: type.toUpperCase(), // server expects FundType (e.g., ENDOWMENT or DONATION)
+      type: type.toUpperCase(),
       description: description.trim(),
       organizationId: userOrgId ?? "",
       units: 0,
@@ -99,136 +89,126 @@ const AddFundModal: React.FC<AddFundModalProps> = ({ children }) => {
       <DialogTrigger asChild onClick={() => setIsOpen(true)}>
         {children}
       </DialogTrigger>
-      <DialogContent className="h-auto w-[700px] rounded-[40px] px-[80px] pb-[40px] pt-[60px]">
-        <ScrollArea className="h-full w-full">
-          <DialogHeader>
-            <DialogTitle className="mb-[32px] text-[28px]">
-              Add Fund
-            </DialogTitle>
-          </DialogHeader>
+      <DialogContent className="w-[480px] rounded-2xl p-8">
+        <VisuallyHidden.Root>
+          <DialogTitle>Add fund</DialogTitle>
+        </VisuallyHidden.Root>
 
-          {/* Name */}
-          <div className="mb-6">
-            <Label htmlFor="name" className="mb-2 block text-lg">
-              Name
-            </Label>
-            <Input
-              id="name"
-              placeholder="Add a name"
-              value={name}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setName(e.target.value)
-              }
+        {/* Title */}
+        <h2 className="mb-6 text-2xl font-bold">Add fund</h2>
+
+        {/* Name */}
+        <div className="mb-5">
+          <label className="mb-1 block text-sm font-medium">
+            Name<span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-400"
+          />
+        </div>
+
+        {/* Type */}
+        <div className="mb-5">
+          <label className="mb-2 block text-sm font-medium">
+            Type<span className="text-red-500">*</span>
+          </label>
+          <RadioGroup
+            value={type}
+            onValueChange={(v) => setType(v as "donation" | "endowment")}
+            className="flex flex-col gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="donation" id="donation" />
+              <Label htmlFor="donation" className="text-sm font-normal">Donation</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="endowment" id="endowment" />
+              <Label htmlFor="endowment" className="text-sm font-normal">Endowment</Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        {/* Restriction — always shown */}
+        <div className="mb-5">
+          <label className="mb-2 block text-sm font-medium">
+            Restriction<span className="text-red-500">*</span>
+          </label>
+          <RadioGroup
+            value={restriction}
+            onValueChange={(v) => setRestriction(v as "restricted" | "unrestricted")}
+            className="flex flex-col gap-2"
+          >
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="restricted" id="restricted" />
+              <Label htmlFor="restricted" className="text-sm font-normal">Restricted</Label>
+            </div>
+            <div className="flex items-center gap-2">
+              <RadioGroupItem value="unrestricted" id="unrestricted" />
+              <Label htmlFor="unrestricted" className="text-sm font-normal">Unrestricted</Label>
+            </div>
+          </RadioGroup>
+        </div>
+
+        {/* Purpose — only for restricted endowments */}
+        {isRestrictedEndowment && (
+          <div className="mb-5">
+            <label className="mb-1 block text-sm font-medium">
+              Purpose<span className="text-red-500">*</span>
+            </label>
+            <textarea
+              placeholder="Describe the restriction purpose"
+              value={purpose}
+              onChange={(e) => setPurpose(e.target.value)}
+              rows={3}
+              className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-400"
             />
           </div>
+        )}
 
-          {/* Type */}
-          <div className="mb-6">
-            <Label className="mb-2 block text-lg">Type</Label>
-            <RadioGroup
-              value={type}
-              onValueChange={(v) => setType(v as "donation" | "endowment")}
-              className="flex flex-col gap-2"
-            >
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="donation" id="donation" />
-                <Label htmlFor="donation">Donation</Label>
-              </div>
-              <div className="flex items-center gap-2">
-                <RadioGroupItem value="endowment" id="endowment" />
-                <Label htmlFor="endowment">Endowment</Label>
-              </div>
-            </RadioGroup>
+        {/* Description */}
+        <div className="mb-6">
+          <div className="mb-1 flex items-center justify-between">
+            <label className="text-sm font-medium">Description</label>
+            <span className="text-xs text-gray-400">Optional</span>
           </div>
+          <textarea
+            placeholder="Add a description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            rows={4}
+            className="w-full resize-none rounded-md border border-gray-300 px-3 py-2 text-sm outline-none focus:border-gray-400"
+          />
+        </div>
 
-          {/* Restriction (only for endowment) */}
-          {type === "endowment" && (
-            <div className="mb-6">
-              <Label className="mb-2 block text-lg">Restriction</Label>
-              <RadioGroup
-                value={restriction}
-                onValueChange={(v) =>
-                  setRestriction(v as "restricted" | "unrestricted")
-                }
-                className="flex flex-col gap-2"
-              >
-                <div className="flex items-center gap-2">
-                  <RadioGroupItem value="restricted" id="restricted" />
-                  <Label htmlFor="restricted">Restricted</Label>
-                </div>
-                <div className="flex items-center gap-2">
-                  <RadioGroupItem value="unrestricted" id="unrestricted" />
-                  <Label htmlFor="unrestricted">Unrestricted</Label>
-                </div>
-              </RadioGroup>
-            </div>
-          )}
+        {/* Error */}
+        {errorMsg && (
+          <div className="mb-4 text-sm text-red-600">{errorMsg}</div>
+        )}
 
-          {/* Purpose (required when restricted endowment) */}
-          {isRestrictedEndowment && (
-            <div className="mb-6">
-              <div className="flex items-center justify-between">
-                <Label htmlFor="purpose" className="text-lg">
-                  Purpose
-                </Label>
-                <span className="text-red-500 text-sm">Required</span>
-              </div>
-              <Input
-                id="purpose"
-                placeholder="Describe the restriction purpose"
-                value={purpose}
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                  setPurpose(e.target.value)
-                }
-                className="border-gray-300 h-32 w-full resize-none rounded-lg border-[1px] px-4 py-2 text-left"
-                as="textarea"
-              />
-            </div>
-          )}
-
-          {/* Description (optional) */}
-          <div className="mb-6">
-            <div className="flex items-center justify-between">
-              <Label htmlFor="description" className="text-lg">
-                Description
-              </Label>
-              <span className="text-gray-300 text-sm">Optional</span>
-            </div>
-            <Input
-              id="description"
-              placeholder="Add a Description"
-              value={description}
-              onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
-                setDescription(e.target.value)
-              }
-              className="border-gray-300 h-32 w-full resize-none rounded-lg border-[1px] px-4 py-2 text-left"
-              as="textarea"
-            />
-          </div>
-
-          {/* Error */}
-          {errorMsg && (
-            <div className="text-red-600 mb-4 text-sm">{errorMsg}</div>
-          )}
-
-          {/* Footer */}
-          <DialogFooter className="mt-8 flex items-center justify-between">
-            <Button
-              variant="secondary"
-              onClick={handleCancel}
-              disabled={submitting}
-            >
-              Cancel
-            </Button>
-            <Button
-              style={{ backgroundColor: "black", color: "white" }}
-              onClick={handleAdd}
-              disabled={submitting}
-            >
-              {submitting ? "Adding..." : "Add"}
-            </Button>
-          </DialogFooter>
-        </ScrollArea>
+        {/* Footer */}
+        <div className="flex items-center justify-between">
+          <button
+            type="button"
+            onClick={handleCancel}
+            disabled={submitting}
+            className="text-sm underline text-gray-600 hover:text-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={submitting}
+            className="rounded-full px-6 py-2 text-sm font-medium text-white"
+            style={{ backgroundColor: "#3E6DA6" }}
+          >
+            {submitting ? "Adding..." : "Add"}
+          </button>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/src/components/molecules/BarGraph.tsx
+++ b/frontend/src/components/molecules/BarGraph.tsx
@@ -1,16 +1,8 @@
 "use client";
-import React, { useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import api from "@/utils/api";
-
-import { Bar, BarChart, CartesianGrid, XAxis } from "recharts";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+import { Bar, BarChart, XAxis, YAxis } from "recharts";
+import { MoreVertical } from "lucide-react";
 import {
   ChartConfig,
   ChartContainer,
@@ -19,9 +11,9 @@ import {
 } from "@/components/ui/chart";
 
 interface ChartData {
-  month: string;
-  desktop: number;
-  mobile: number;
+  label: string;
+  light: number;
+  dark: number;
 }
 
 const calendarOrder = [
@@ -40,51 +32,95 @@ const calendarOrder = [
 ];
 
 const chartConfig = {
-  desktop: {
-    label: "Desktop",
+  light: {
+    label: "Donations",
     color: "#88AEDC",
   },
-  mobile: {
-    label: "Mobile",
+  dark: {
+    label: "Investments",
     color: "#3E6DA6",
   },
 } satisfies ChartConfig;
 
-export function BarGraph() {
+type Range = "last-year" | "last-6m" | "today";
+
+interface BarGraphProps {
+  total?: number;
+  range?: Range;
+  onRangeChange?: (range: Range) => void;
+}
+
+export function BarGraph({ total, range: rangeProp, onRangeChange }: BarGraphProps) {
   const [chartData, setChartData] = useState<ChartData[]>([]);
-  const [range, setRange] = useState<"6m" | "1y">("6m");
+  const [internalRange, setInternalRange] = useState<Range>("last-year");
+  const range = rangeProp ?? internalRange;
+  const setRange = (r: Range) => {
+    if (onRangeChange) onRangeChange(r);
+    else setInternalRange(r);
+  };
+  const [count, setCount] = useState<number>(0);
 
   useEffect(() => {
     const fetchData = async () => {
       try {
-        const res = await api.get("/transactions?type=DONATION");
-        const transactions = res.data.transactions;
+        const res = await api.get("/transactions");
+        const transactions = res.data.transactions ?? [];
 
         const now = new Date();
-        const cutoff = new Date();
-        cutoff.setMonth(
-          range === "6m" ? now.getMonth() - 5 : now.getMonth() - 11
-        );
+        const cutoff = new Date(now);
+        if (range === "last-year") cutoff.setFullYear(now.getFullYear() - 1);
+        else if (range === "last-6m") cutoff.setMonth(now.getMonth() - 5);
+        else cutoff.setHours(0, 0, 0, 0);
 
-        const grouped: Record<string, number> = {};
-
-        const filtered = transactions.filter((tx: any) => {
-          const txDate = new Date(tx.date);
-          return txDate >= cutoff && txDate <= now;
+        const filtered = transactions.filter((tx: { date: string }) => {
+          const d = new Date(tx.date);
+          return d >= cutoff && d <= now;
         });
 
-        filtered.forEach((tx: any) => {
+        setCount(filtered.length);
+
+        if (range === "today") {
+          // Group by hour-of-day for "Today" view
+          const buckets: Record<number, { light: number; dark: number }> = {};
+          for (let h = 0; h < 24; h += 3) buckets[h] = { light: 0, dark: 0 };
+          filtered.forEach((tx: { date: string; type: string }) => {
+            const hour = new Date(tx.date).getHours();
+            const bucket = Math.floor(hour / 3) * 3;
+            if (!buckets[bucket]) buckets[bucket] = { light: 0, dark: 0 };
+            if (tx.type === "INVESTMENT")
+              buckets[bucket].dark += 1;
+            else buckets[bucket].light += 1;
+          });
+          const formatted = Object.entries(buckets).map(([h, v]) => {
+            const hourNum = parseInt(h, 10);
+            const ampm = hourNum >= 12 ? "pm" : "am";
+            const display = hourNum === 0 ? 12 : hourNum > 12 ? hourNum - 12 : hourNum;
+            return {
+              label: `${display}:00${ampm}`,
+              light: v.light,
+              dark: v.dark,
+            };
+          });
+          setChartData(formatted);
+          return;
+        }
+
+        // Group by month
+        const grouped: Record<string, { light: number; dark: number }> = {};
+        filtered.forEach((tx: { date: string; type: string }) => {
           const date = new Date(tx.date);
           const month = date.toLocaleString("default", { month: "long" });
-          grouped[month] = (grouped[month] || 0) + tx.amount;
+          if (!grouped[month]) grouped[month] = { light: 0, dark: 0 };
+          if (tx.type === "INVESTMENT") grouped[month].dark += 1;
+          else grouped[month].light += 1;
         });
 
         const formatted = calendarOrder
-          .filter((month) => grouped[month])
-          .map((month) => ({
-            month,
-            desktop: Math.round(grouped[month] * 0.6),
-            mobile: Math.round(grouped[month] * 0.4),
+          .filter((m) => grouped[m])
+          .map((m) => ({
+            label: m.slice(0, 3),
+            light: grouped[m].light,
+            dark: grouped[m].dark,
           }));
 
         setChartData(formatted);
@@ -93,67 +129,71 @@ export function BarGraph() {
       }
     };
 
-    fetchData();
+    void fetchData();
   }, [range]);
 
+  const displayedTotal = total ?? count;
+
   return (
-    <Card>
-      <CardHeader>
-        <div className="flex items-center justify-between">
-          <div>
-            <CardTitle>Contributions Per Month</CardTitle>
-            <CardDescription>
-              {range === "6m" ? "Last 6 Months" : "Last Year"}
-            </CardDescription>
+    <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
+      <div className="mb-6 flex items-start justify-between">
+        <div>
+          <div className="text-[28px] font-bold leading-none text-gray-900">
+            {displayedTotal}
           </div>
-          <div className="flex space-x-2">
-            <button
-              className={`rounded-lg px-3 py-1 text-sm font-medium ${
-                range === "6m" ? "bg-blue-100 text-blue-800" : "bg-gray-200" }`}
-              onClick={() => setRange("6m")}
-            >
-              Last 6 Months
-            </button>
-            <button
-              className={`rounded-lg px-3 py-1 text-sm font-medium ${
-                range === "1y" ? "bg-blue-100 text-blue-800" : "bg-gray-200" }`}
-              onClick={() => setRange("1y")}
-            >
-              Last Year
-            </button>
-          </div>
+          <div className="mt-1.5 text-sm text-gray-400">Contributions</div>
         </div>
-      </CardHeader>
+        <div className="flex items-center gap-5 text-sm">
+          {(
+            [
+              ["last-year", "Last Year"],
+              ["last-6m", "Last 6 Months"],
+              ["today", "Today"],
+            ] as [Range, string][]
+          ).map(([val, label]) => (
+            <button
+              key={val}
+              onClick={() => setRange(val)}
+              className={
+                range === val
+                  ? "font-semibold text-gray-900"
+                  : "text-gray-400 hover:text-gray-600"
+              }
+            >
+              {label}
+            </button>
+          ))}
+          <button className="text-gray-400 hover:text-gray-600">
+            <MoreVertical size={18} />
+          </button>
+        </div>
+      </div>
 
-      <CardContent>
-        <ChartContainer config={chartConfig}>
-          <BarChart data={chartData}>
-            <CartesianGrid vertical={false} />
-            <XAxis
-              dataKey="month"
-              tickLine={false}
-              tickMargin={10}
-              axisLine={false}
-              tickFormatter={(value) => value.slice(0, 3)}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent indicator="dashed" />}
-            />
-            <Bar
-              dataKey="desktop"
-              fill={chartConfig.desktop.color}
-              radius={4}
-            />
-            <Bar dataKey="mobile" fill={chartConfig.mobile.color} radius={4} />
-          </BarChart>
-        </ChartContainer>
-      </CardContent>
-
-      <CardFooter className="text-sm text-muted-foreground">
-        Showing total contributions for the selected time range
-      </CardFooter>
-    </Card>
+      <ChartContainer config={chartConfig} className="aspect-auto h-[280px] w-full">
+        <BarChart data={chartData} barCategoryGap="20%">
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            tickMargin={10}
+            axisLine={false}
+            interval="preserveStartEnd"
+            tick={{ fill: "#9CA3AF", fontSize: 11 }}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            tick={{ fill: "#9CA3AF", fontSize: 11 }}
+            width={28}
+          />
+          <ChartTooltip
+            cursor={false}
+            content={<ChartTooltipContent indicator="dashed" />}
+          />
+          <Bar dataKey="light" fill={chartConfig.light.color} radius={[3, 3, 0, 0]} />
+          <Bar dataKey="dark" fill={chartConfig.dark.color} radius={[3, 3, 0, 0]} />
+        </BarChart>
+      </ChartContainer>
+    </div>
   );
 }
 

--- a/frontend/src/components/molecules/ContributionsGraph.tsx
+++ b/frontend/src/components/molecules/ContributionsGraph.tsx
@@ -1,11 +1,7 @@
 "use client";
 import * as React from "react";
-import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-} from "@/components/ui/card";
+import { Line, LineChart, XAxis, YAxis } from "recharts";
+import { MoreVertical } from "lucide-react";
 import {
   ChartConfig,
   ChartContainer,
@@ -18,176 +14,204 @@ type TransactionType = "DONATION" | "WITHDRAWAL" | "INVESTMENT" | "EXPENSE";
 
 interface Transaction {
   id: string;
-  organizationId: string;
-  contributorId?: string;
   type: TransactionType;
   date: string;
-  units?: number;
   amount: number;
-  description?: string;
-  createdAt: string;
-  updatedAt: string;
-  contributor: {
-    id: string;
-    firstName: string;
-    lastName: string;
-  };
-  organization: {
-    id: string;
-    name: string;
-    type: string;
-    restriction: string;
-  };
 }
 
+type Range = "last-month" | "last-year" | "all";
 
-const fetchTransactions = async (fundId?: string) => {
+interface Point {
+  date: Date;
+  value: number;
+}
+
+const fetchTransactions = async (fundId?: string): Promise<Transaction[]> => {
   try {
     const url = fundId ? `/funds/${fundId}/transactions` : `/transactions`;
     const response = await api.get(url);
-    const data = response.data;
-    const txList: Transaction[] = data.transactions ?? [];
-    if (txList.length === 0) return [];
-
-    let cumulativeAmount = 0;
-
-    return (txList as Transaction[])
-      .filter(
-        (t) =>
-          t.type === "DONATION" || t.type === "INVESTMENT"
-      )
-      .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
-      .map((transaction: { amount: number; date: string | number | Date }) => {
-        cumulativeAmount += transaction.amount;
-        return {
-          month: new Date(transaction.date).toLocaleDateString("en-US", {
-            month: "short",
-            day: "numeric",
-          }),
-          date: new Date(transaction.date),
-          desktop: cumulativeAmount,
-        };
-      });
+    return response.data.transactions ?? [];
   } catch (error) {
     console.error("Error fetching transactions:", error);
     return [];
   }
 };
 
-// Format a date to "MMM d" format (e.g., "Mar 3")
-const formatDate = (date: Date) => {
-  return date.toLocaleDateString("en-US", {
-    month: "short",
-    day: "numeric",
-  });
+const formatDate = (date: Date) =>
+  date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+
+const formatK = (n: number) => {
+  if (Math.abs(n) >= 1000) return `${(n / 1000).toFixed(0)}K`;
+  return `${n}`;
 };
+
+const chartConfig = {
+  value: { label: "Amount $", color: "black" },
+} satisfies ChartConfig;
 
 interface ContributionsGraphProps {
   fundId?: string;
+  range?: Range;
+  onRangeChange?: (range: Range) => void;
 }
 
-export function ContributionsGraph({ fundId }: ContributionsGraphProps) {
-  const [chartData, setChartData] = React.useState<{ month: string; date: Date; desktop: number }[]>([]);
-  const [xAxisTicks, setXAxisTicks] = React.useState<number[]>([]);
-  const [formattedTicks, setFormattedTicks] = React.useState<Record<number, string>>({});
-  const [total, setTotal] = React.useState<number | null>(null);
-
-  React.useEffect(() => {
-    fetchTransactions(fundId).then((data) => {
-      if (data.length === 0) return;
-
-      setChartData(data);
-      setTotal(data[data.length - 1].desktop);
-
-      // Generate 5 evenly spaced dates between the earliest and latest data point
-      const firstDate = data[0].date.getTime();
-      const lastDate = data[data.length - 1].date.getTime();
-      let tickTimestamps: number[] = [];
-
-      if (firstDate === lastDate) { //only 1 point
-        const offset = 1000 * 60 * 60 * 24; // 1 day in milliseconds
-        tickTimestamps = [firstDate - offset, firstDate, firstDate + offset];
-      } else { // > 2 points
-        const timeRange = lastDate - firstDate;
-        for (let i = 0; i < 5; i++) {
-          const timestamp = Math.round(firstDate + (timeRange * i) / 4);
-          tickTimestamps.push(timestamp);
-        }
-      }
-      
-      // Convert timestamps to formatted date strings
-      const ticksObj: Record<number, string> = {};
-      tickTimestamps.forEach((timestamp) => {
-        const date = new Date(timestamp);
-        ticksObj[date.getTime()] = formatDate(date);
-      });
-
-      setFormattedTicks(ticksObj);
-      setXAxisTicks(tickTimestamps);
-    });
-  }, []);
-
-  // Custom tick formatter function for the X axis
-  const formatXAxisTick = (timestamp: string | number) => {
-    return formattedTicks[Number(timestamp)] || "";
+export function ContributionsGraph({
+  fundId,
+  range: rangeProp,
+  onRangeChange,
+}: ContributionsGraphProps) {
+  const [allPoints, setAllPoints] = React.useState<Point[]>([]);
+  const [internalRange, setInternalRange] = React.useState<Range>("last-month");
+  const range = rangeProp ?? internalRange;
+  const setRange = (r: Range) => {
+    if (onRangeChange) onRangeChange(r);
+    else setInternalRange(r);
   };
 
-  const chartConfig = {
-    desktop: {
-      label: "Amount $",
-      color: "black",
-    },
-  } satisfies ChartConfig;
+  React.useEffect(() => {
+    fetchTransactions(fundId).then((txs) => {
+      const sorted = txs
+        .filter((t) => ["DONATION", "INVESTMENT", "WITHDRAWAL", "EXPENSE"].includes(t.type))
+        .sort(
+          (a, b) => new Date(a.date).getTime() - new Date(b.date).getTime(),
+        );
+      let cumulative = 0;
+      const points: Point[] = sorted.map((t) => {
+        if (t.type === "WITHDRAWAL" || t.type === "EXPENSE") {
+          cumulative -= t.amount;
+        } else {
+          cumulative += t.amount;
+        }
+        return { date: new Date(t.date), value: cumulative };
+      });
+      setAllPoints(points);
+    });
+  }, [fundId]);
+
+  const filteredPoints = React.useMemo(() => {
+    if (allPoints.length === 0) return [];
+    if (range === "all") return allPoints;
+    const now = new Date();
+    const cutoff = new Date(now);
+    if (range === "last-month") cutoff.setMonth(now.getMonth() - 1);
+    else cutoff.setFullYear(now.getFullYear() - 1);
+    const filtered = allPoints.filter((p) => p.date >= cutoff);
+    return filtered.length > 0 ? filtered : allPoints.slice(-2);
+  }, [allPoints, range]);
+
+  const chartData = filteredPoints.map((p) => ({
+    timestamp: p.date.getTime(),
+    value: p.value,
+  }));
+
+  const total = React.useMemo(() => {
+    if (filteredPoints.length === 0) return 0;
+    const last = filteredPoints[filteredPoints.length - 1].value;
+    if (range === "all") return last;
+    const cutoff = filteredPoints[0].date;
+    const pointsBefore = allPoints.filter((p) => p.date < cutoff);
+    const valueBeforeRange = pointsBefore.length > 0 ? pointsBefore[pointsBefore.length - 1].value : 0;
+    return last - valueBeforeRange;
+  }, [filteredPoints, allPoints, range]);
+
+  // Build evenly spaced ticks
+  const xAxisTicks = React.useMemo<number[]>(() => {
+    if (filteredPoints.length === 0) return [];
+    const first = filteredPoints[0].date.getTime();
+    const last = filteredPoints[filteredPoints.length - 1].date.getTime();
+    if (first === last) {
+      const day = 86_400_000;
+      return [first - day, first, first + day];
+    }
+    const out: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      out.push(Math.round(first + ((last - first) * i) / 4));
+    }
+    return out;
+  }, [filteredPoints]);
+
+  const formatXAxisTick = (timestamp: string | number) => {
+    const date = new Date(Number(timestamp));
+    return formatDate(date);
+  };
 
   return (
-    <Card>
-      <CardHeader>
-        {total !== null && (
-          <div>
-            <div className="text-sm text-gray-500">Overall Contributions</div>
-            <div className="text-3xl font-bold">
-              {new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(total)}
-            </div>
+    <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-[0_1px_3px_rgba(0,0,0,0.05)]">
+      <div className="mb-4 flex items-start justify-between">
+        <div>
+          <div className="text-sm text-gray-400">Account Balance</div>
+          <div className="mt-1 text-[30px] font-bold leading-none text-gray-900">
+            {new Intl.NumberFormat("en-US", {
+              style: "currency",
+              currency: "USD",
+            }).format(total)}
           </div>
-        )}
-      </CardHeader>
-      <CardContent>
-        <ChartContainer config={chartConfig} className="aspect-auto h-[400px]">
-          <LineChart
-            accessibilityLayer
-            data={chartData}
-            margin={{ left: 12, right: 12, top: 12 }}
-          >
-            <CartesianGrid vertical={false} horizontal={false} />
-            <YAxis dataKey="desktop" tickLine={false} axisLine={false} />
-            <XAxis
-              dataKey="date"
-              tickLine={false}
-              axisLine={false}
-              tickMargin={8}
-              ticks={xAxisTicks}
-              tickFormatter={formatXAxisTick}
-              type="number"
-              domain={[
-                chartData[0]?.date?.getTime(),
-                chartData[chartData.length - 1]?.date?.getTime(),
-              ]}
-            />
-            <ChartTooltip
-              cursor={false}
-              content={<ChartTooltipContent hideLabel />}
-            />
-            <Line
-              dataKey="desktop"
-              type="linear"
-              stroke="black"
-              strokeWidth={2}
-              dot={false}
-            />
-          </LineChart>
-        </ChartContainer>
-      </CardContent>
-    </Card>
+        </div>
+        <div className="flex items-center gap-5 text-sm">
+          {(
+            [
+              ["last-month", "Last Month"],
+              ["last-year", "Last Year"],
+              ["all", "All"],
+            ] as [Range, string][]
+          ).map(([val, label]) => (
+            <button
+              key={val}
+              onClick={() => setRange(val)}
+              className={
+                range === val
+                  ? "font-semibold text-gray-900"
+                  : "text-gray-400 hover:text-gray-600"
+              }
+            >
+              {label}
+            </button>
+          ))}
+          <button className="text-gray-400 hover:text-gray-600">
+            <MoreVertical size={18} />
+          </button>
+        </div>
+      </div>
+
+      <ChartContainer config={chartConfig} className="aspect-auto h-[340px] w-full">
+        <LineChart
+          accessibilityLayer
+          data={chartData}
+          margin={{ left: 4, right: 12, top: 16, bottom: 4 }}
+        >
+          <YAxis
+            dataKey="value"
+            tickLine={false}
+            axisLine={false}
+            tickFormatter={formatK}
+            tick={{ fill: "#9CA3AF", fontSize: 11 }}
+            width={36}
+          />
+          <XAxis
+            dataKey="timestamp"
+            tickLine={false}
+            axisLine={false}
+            tickMargin={10}
+            ticks={xAxisTicks}
+            tickFormatter={formatXAxisTick}
+            tick={{ fill: "#9CA3AF", fontSize: 11 }}
+            type="number"
+            domain={["dataMin", "dataMax"]}
+          />
+          <ChartTooltip
+            cursor={false}
+            content={<ChartTooltipContent hideLabel />}
+          />
+          <Line
+            dataKey="value"
+            type="linear"
+            stroke="#111827"
+            strokeWidth={1.5}
+            dot={false}
+          />
+        </LineChart>
+      </ChartContainer>
+    </div>
   );
 }
 

--- a/frontend/src/components/molecules/ContributionsGraph.tsx
+++ b/frontend/src/components/molecules/ContributionsGraph.tsx
@@ -90,12 +90,14 @@ export function ContributionsGraph({ fundId }: ContributionsGraphProps) {
   const [chartData, setChartData] = React.useState<{ month: string; date: Date; desktop: number }[]>([]);
   const [xAxisTicks, setXAxisTicks] = React.useState<number[]>([]);
   const [formattedTicks, setFormattedTicks] = React.useState<Record<number, string>>({});
+  const [total, setTotal] = React.useState<number | null>(null);
 
   React.useEffect(() => {
     fetchTransactions(fundId).then((data) => {
       if (data.length === 0) return;
 
       setChartData(data);
+      setTotal(data[data.length - 1].desktop);
 
       // Generate 5 evenly spaced dates between the earliest and latest data point
       const firstDate = data[0].date.getTime();
@@ -139,7 +141,16 @@ export function ContributionsGraph({ fundId }: ContributionsGraphProps) {
 
   return (
     <Card>
-      <CardHeader></CardHeader>
+      <CardHeader>
+        {total !== null && (
+          <div>
+            <div className="text-sm text-gray-500">Overall Contributions</div>
+            <div className="text-3xl font-bold">
+              {new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(total)}
+            </div>
+          </div>
+        )}
+      </CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig} className="aspect-auto h-[400px]">
           <LineChart

--- a/frontend/src/components/molecules/ContributionsGraph.tsx
+++ b/frontend/src/components/molecules/ContributionsGraph.tsx
@@ -4,9 +4,7 @@ import { CartesianGrid, Line, LineChart, XAxis, YAxis } from "recharts";
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
-  CardTitle,
 } from "@/components/ui/card";
 import {
   ChartConfig,
@@ -43,22 +41,20 @@ interface Transaction {
 }
 
 
-const fetchTransactions = async () => {
+const fetchTransactions = async (fundId?: string) => {
   try {
-    const response = await api.get(`/transactions`);
+    const url = fundId ? `/funds/${fundId}/transactions` : `/transactions`;
+    const response = await api.get(url);
     const data = response.data;
-    if (!data.transactions) return [];
-
-    const lastMonthDate = new Date();
-    lastMonthDate.setMonth(lastMonthDate.getMonth() - 1);
+    const txList: Transaction[] = data.transactions ?? [];
+    if (txList.length === 0) return [];
 
     let cumulativeAmount = 0;
 
-    return (data.transactions as Transaction[])
+    return (txList as Transaction[])
       .filter(
         (t) =>
-          (t.type === "DONATION" || t.type === "INVESTMENT") &&
-          new Date(t.date) >= lastMonthDate
+          t.type === "DONATION" || t.type === "INVESTMENT"
       )
       .sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime())
       .map((transaction: { amount: number; date: string | number | Date }) => {
@@ -86,18 +82,20 @@ const formatDate = (date: Date) => {
   });
 };
 
-export function ContributionsGraph() {
+interface ContributionsGraphProps {
+  fundId?: string;
+}
+
+export function ContributionsGraph({ fundId }: ContributionsGraphProps) {
   const [chartData, setChartData] = React.useState<{ month: string; date: Date; desktop: number }[]>([]);
-  const [totalAmount, setTotalAmount] = React.useState(0);
   const [xAxisTicks, setXAxisTicks] = React.useState<number[]>([]);
   const [formattedTicks, setFormattedTicks] = React.useState<Record<number, string>>({});
 
   React.useEffect(() => {
-    fetchTransactions().then((data) => {
+    fetchTransactions(fundId).then((data) => {
       if (data.length === 0) return;
 
       setChartData(data);
-      setTotalAmount(data.length > 0 ? data[data.length - 1].desktop : 0);
 
       // Generate 5 evenly spaced dates between the earliest and latest data point
       const firstDate = data[0].date.getTime();
@@ -141,12 +139,7 @@ export function ContributionsGraph() {
 
   return (
     <Card>
-      <CardHeader>
-        <CardTitle>Overall Contributions</CardTitle>
-        <CardDescription>
-          ${totalAmount ? totalAmount.toLocaleString() : "0"}
-        </CardDescription>
-      </CardHeader>
+      <CardHeader></CardHeader>
       <CardContent>
         <ChartContainer config={chartConfig} className="aspect-auto h-[400px]">
           <LineChart

--- a/frontend/src/components/molecules/ContributorsTable.tsx
+++ b/frontend/src/components/molecules/ContributorsTable.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
 import { SimpleTable, Column } from "@/components/molecules/SimpleTable";
 import api from "@/utils/api";
 
@@ -16,28 +17,20 @@ interface Transaction {
   description?: string;
   createdAt: string;
   updatedAt: string;
-  contributor: {
-    id: string;
-    firstName: string;
-    lastName: string;
-  };
-  organization: {
-    id: string;
-    name: string;
-    type: string;
-    restriction: string;
-  };
+}
+
+interface Fund {
+  id: string;
+  name: string;
 }
 
 interface Contributor {
   id: string;
   firstName: string;
   lastName: string;
-  organization: {
-    id: string;
-    name: string;
-  };
+  organization: { id: string; name: string };
   transactions: Transaction[];
+  funds: Fund[];
   updatedAt: string;
 }
 
@@ -45,20 +38,73 @@ interface TableData {
   id: string;
   date: string;
   contributor: string;
-  amount: number | null; // Store as a number for sorting
+  fund: string;
+  amount: number | null;
   hasTransactions: boolean;
 }
 
+export type ContributorSortBy =
+  | "date-desc" | "date-asc"
+  | "name-asc" | "name-desc"
+  | "amount-desc" | "amount-asc";
+
 interface ContributorsTableProps {
-  searchQuery?: string; // New prop to filter by contributor name
-  refreshToken?: number; // bump this value to force a refetch
+  searchQuery?: string;
+  refreshToken?: number;
+  sortBy?: ContributorSortBy;
+}
+
+function ThreeDotsMenu({ contributorId: _contributorId }: { contributorId: string }) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <button
+        onClick={(e) => { e.stopPropagation(); setOpen((o) => !o); }}
+        className="rounded p-1 hover:bg-gray-100 text-gray-400 hover:text-gray-600"
+      >
+        ⋮
+      </button>
+      {open && (
+        <div
+          className="absolute right-0 top-7 z-50 min-w-[140px] rounded-lg bg-white p-1 text-sm"
+          style={{ boxShadow: "0 4px 24px rgba(0,0,0,0.18)" }}
+        >
+          <button
+            className="w-full rounded px-3 py-2 text-left hover:bg-gray-50"
+            onClick={() => setOpen(false)}
+          >
+            View details
+          </button>
+          <button
+            className="w-full rounded px-3 py-2 text-left text-red-500 hover:bg-gray-50"
+            onClick={() => setOpen(false)}
+          >
+            Delete
+          </button>
+        </div>
+      )}
+    </div>
+  );
 }
 
 const ContributorsTable: React.FC<ContributorsTableProps> = ({
-  searchQuery = "", // Default to empty string if not provided
+  searchQuery = "",
   refreshToken = 0,
+  sortBy = "date-desc",
 }) => {
   const PAGE_SIZE = 5;
+  const router = useRouter();
   const [contributors, setContributors] = useState<TableData[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
@@ -70,17 +116,17 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
   const fetchContributors = async () => {
     setLoading(true);
     setError(null);
-
     try {
       const response = await api.get("/contributors");
       const data = response.data;
-      console.log("Fetched", data);
 
       if (data && data.contributors) {
-        const mappedData = data.contributors.map((contributor: Contributor) => {
+        const mappedData: TableData[] = data.contributors.map((contributor: Contributor) => {
           const hasTransactions = contributor.transactions.length > 0;
           const latestTransaction = hasTransactions
-            ? contributor.transactions[contributor.transactions.length - 1]
+            ? [...contributor.transactions].sort(
+                (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
+              )[0]
             : null;
 
           const activityDate = latestTransaction
@@ -88,28 +134,26 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
             : new Date(contributor.updatedAt).toLocaleDateString();
 
           const formattedAmount = latestTransaction
-            ? latestTransaction.type === "EXPENSE" ||
-              latestTransaction.type === "WITHDRAWAL"
+            ? latestTransaction.type === "EXPENSE" || latestTransaction.type === "WITHDRAWAL"
               ? -Math.abs(latestTransaction.amount)
               : Math.abs(latestTransaction.amount)
             : null;
+
+          const fundName = contributor.funds?.length > 0
+            ? contributor.funds.map((f) => f.name).join(", ")
+            : "—";
 
           return {
             id: contributor.id,
             date: activityDate,
             contributor: `${contributor.firstName} ${contributor.lastName}`,
-            amount: formattedAmount, // Will be null when no transactions
-            hasTransactions: hasTransactions,
+            fund: fundName,
+            amount: formattedAmount,
+            hasTransactions,
           };
         });
 
-        // Sort contributors by date in descending order before setting the state
-        const sortedData: TableData[] = mappedData.sort(
-          (a: TableData, b: TableData) =>
-            new Date(b.date).getTime() - new Date(a.date).getTime()
-        );
-
-        setContributors(sortedData); // Update state with sorted data
+        setContributors(mappedData);
       }
     } catch (err) {
       console.error("Error fetching contributors:", err);
@@ -119,53 +163,34 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
     }
   };
 
-  // Enables “search anything” on the table:
-  // normalize the query, and if present, build a combined text string per row
-  // (date, name, fund, amount, status, id) and keep rows that contain the query.
   const filteredContributors = useMemo(() => {
     const q = (searchQuery ?? "").trim().toLowerCase();
-    if (!q) return contributors;
+    let result = contributors;
 
-    const rowText = (r: TableData) => {
-      const amountStr =
-        r.amount === null || r.amount === undefined
-          ? "no transactions found"
-          : (() => {
-              const sign = r.amount < 0 ? "-" : "+";
-              const amt = new Intl.NumberFormat("en-US", {
-                style: "currency",
-                currency: "USD",
-              }).format(Math.abs(r.amount));
-              return `${sign}${amt}`;
-            })();
+    if (q) {
+      result = result.filter((r) =>
+        [r.date, r.contributor, r.fund, r.amount?.toString() ?? "", r.id]
+          .join(" ")
+          .toLowerCase()
+          .includes(q)
+      );
+    }
 
-      return [
-        r.date,
-        r.contributor,
-        amountStr,
-        r.hasTransactions ? "has transactions" : "no transactions",
-        r.id,
-      ]
-        .join(" ")
-        .toLowerCase();
-    };
-
-    return contributors.filter((r) => rowText(r).includes(q));
-  }, [contributors, searchQuery]);
+    return [...result].sort((a, b) => {
+      if (sortBy === "date-desc") return new Date(b.date).getTime() - new Date(a.date).getTime();
+      if (sortBy === "date-asc") return new Date(a.date).getTime() - new Date(b.date).getTime();
+      if (sortBy === "name-asc") return a.contributor.localeCompare(b.contributor);
+      if (sortBy === "name-desc") return b.contributor.localeCompare(a.contributor);
+      if (sortBy === "amount-desc") return (b.amount ?? 0) - (a.amount ?? 0);
+      if (sortBy === "amount-asc") return (a.amount ?? 0) - (b.amount ?? 0);
+      return 0;
+    });
+  }, [contributors, searchQuery, sortBy]);
 
   const columns: Column<TableData>[] = [
-    {
-      header: "Date",
-      accessor: "date",
-      dataType: "date",
-      sortable: true,
-    },
-    {
-      header: "Contributor",
-      accessor: "contributor",
-      dataType: "string",
-      sortable: true,
-    },
+    { header: "Date", accessor: "date", dataType: "date", sortable: true },
+    { header: "Contributor", accessor: "contributor", dataType: "string", sortable: true },
+    { header: "Fund", accessor: "fund", dataType: "string", sortable: true },
     {
       header: "Amount",
       accessor: "amount",
@@ -174,48 +199,42 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
       headerClassName: "text-right",
       className: "text-right font-medium",
       Cell: (value) => {
-        if (value === null) {
-          return <span className="text-gray-500">No Transactions Found</span>;
-        }
-
+        if (value === null) return <span className="text-gray-400">—</span>;
         return (
           <span style={{ color: value < 0 ? "red" : "green" }}>
             {value < 0 ? "-" : "+"}
-            {new Intl.NumberFormat("en-US", {
-              style: "currency",
-              currency: "USD",
-            }).format(Math.abs(value))}
+            {new Intl.NumberFormat("en-US", { style: "currency", currency: "USD" }).format(Math.abs(value))}
           </span>
         );
       },
     },
+    {
+      header: "",
+      accessor: "id",
+      dataType: "string",
+      sortable: false,
+      className: "w-8 text-right",
+      Cell: (value) => <ThreeDotsMenu contributorId={value} />,
+    },
   ];
 
-  if (loading) {
-    return <div>Loading contributors...</div>;
-  }
-
-  if (error) {
-    return (
-      <div className="bg-red-100 text-red-700 rounded p-3 text-sm">{error}</div>
-    );
-  }
+  if (loading) return <div>Loading contributors...</div>;
+  if (error) return <div className="bg-red-100 text-red-700 rounded p-3 text-sm">{error}</div>;
 
   return (
     <div>
-      {/* Display search results message if filtering */}
-      {searchQuery && searchQuery.trim() !== "" && (
+      {searchQuery?.trim() && (
         <div className="mb-4 text-sm">
           {filteredContributors.length === 0
             ? `No contributors found for "${searchQuery}"`
             : `Showing ${filteredContributors.length} contributor${filteredContributors.length !== 1 ? "s" : ""} for "${searchQuery}"`}
         </div>
       )}
-
       <SimpleTable<TableData>
-        data={filteredContributors} // Use the filtered data
+        data={filteredContributors}
         columns={columns}
         pageSize={PAGE_SIZE}
+        onRowClick={(row) => router.push(`/contributors/${row.id}`)}
       />
     </div>
   );

--- a/frontend/src/components/molecules/ContributorsTable.tsx
+++ b/frontend/src/components/molecules/ContributorsTable.tsx
@@ -41,6 +41,7 @@ interface TableData {
   fund: string;
   amount: number | null;
   hasTransactions: boolean;
+  transactionTypes: TransactionType[];
 }
 
 export type ContributorSortBy =
@@ -48,10 +49,13 @@ export type ContributorSortBy =
   | "name-asc" | "name-desc"
   | "amount-desc" | "amount-asc";
 
+export type ContributorFilterBy = "all" | "DONATION" | "INVESTMENT" | "WITHDRAWAL" | "EXPENSE" | "no-transactions";
+
 interface ContributorsTableProps {
   searchQuery?: string;
   refreshToken?: number;
   sortBy?: ContributorSortBy;
+  filterBy?: ContributorFilterBy;
 }
 
 function ThreeDotsMenu({ contributorId: _contributorId }: { contributorId: string }) {
@@ -102,6 +106,7 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
   searchQuery = "",
   refreshToken = 0,
   sortBy = "date-desc",
+  filterBy = "all",
 }) => {
   const PAGE_SIZE = 5;
   const router = useRouter();
@@ -150,6 +155,7 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
             fund: fundName,
             amount: formattedAmount,
             hasTransactions,
+            transactionTypes: contributor.transactions.map((t) => t.type),
           };
         });
 
@@ -166,6 +172,12 @@ const ContributorsTable: React.FC<ContributorsTableProps> = ({
   const filteredContributors = useMemo(() => {
     const q = (searchQuery ?? "").trim().toLowerCase();
     let result = contributors;
+
+    if (filterBy === "no-transactions") {
+      result = result.filter((r) => !r.hasTransactions);
+    } else if (filterBy !== "all") {
+      result = result.filter((r) => r.transactionTypes.includes(filterBy as TransactionType));
+    }
 
     if (q) {
       result = result.filter((r) =>

--- a/frontend/src/components/molecules/FundsCardTable.tsx
+++ b/frontend/src/components/molecules/FundsCardTable.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import { useState, useEffect } from "react";
 import FundCard from "./FundCard";
 
 // connected api
@@ -38,23 +38,48 @@ interface FundCardProps {
   description: string;
 }
 
+type FundFilterType = "all" | "Endowment" | "Donation";
+type FundFilterRestriction = "all" | "Restricted" | "Unrestricted";
+type FundSortBy = "name-asc" | "name-desc" | "amount-asc" | "amount-desc" | "newest" | "oldest";
+
 export default function FundsCardTable({
   searchQuery,
+  filterType = "all",
+  filterRestriction = "all",
+  sortBy = "newest",
 }: {
   searchQuery: string;
+  filterType?: FundFilterType;
+  filterRestriction?: FundFilterRestriction;
+  sortBy?: FundSortBy;
 }) {
   const [funds, setFunds] = useState<FundCardProps[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-
-  // Checks if there's a search term. If yes, only keep funds whose names include it (ignoring case).
-  // If not, show all funds.
-  const filteredFunds = searchQuery
-    ? funds.filter((fund) =>
-        (fund.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
-      )
-    : funds;
+  let filteredFunds = funds;
+  if (searchQuery) {
+    filteredFunds = filteredFunds.filter((f) =>
+      (f.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  }
+  if (filterType !== "all") {
+    filteredFunds = filteredFunds.filter((f) =>
+      filterType === "Endowment" ? f.isEndowment : !f.isEndowment
+    );
+  }
+  if (filterRestriction !== "all") {
+    filteredFunds = filteredFunds.filter((f) =>
+      filterRestriction === "Restricted" ? f.isRestricted : !f.isRestricted
+    );
+  }
+  filteredFunds = [...filteredFunds].sort((a, b) => {
+    if (sortBy === "name-asc") return a.name.localeCompare(b.name);
+    if (sortBy === "name-desc") return b.name.localeCompare(a.name);
+    if (sortBy === "amount-asc") return a.amount - b.amount;
+    if (sortBy === "amount-desc") return b.amount - a.amount;
+    return 0; // newest/oldest handled by fetch order
+  });
 
   useEffect(() => {
     fetchFunds();

--- a/frontend/src/components/molecules/FundsListTable.tsx
+++ b/frontend/src/components/molecules/FundsListTable.tsx
@@ -2,7 +2,6 @@
 
 import React, { useState, useEffect } from "react";
 import { Bookmark } from "lucide-react";
-import { cn } from "@/lib/utils";
 import { useRouter } from "next/navigation";
 import api from "@/utils/api";
 
@@ -34,23 +33,46 @@ type Fund = {
   amount: number;
 };
 
-export default function FundsCardTable({
+type FundFilterType = "all" | "Endowment" | "Donation";
+type FundFilterRestriction = "all" | "Restricted" | "Unrestricted";
+type FundSortBy = "name-asc" | "name-desc" | "amount-asc" | "amount-desc" | "newest" | "oldest";
+
+export default function FundsListTable({
   searchQuery,
+  filterType = "all",
+  filterRestriction = "all",
+  sortBy = "newest",
 }: {
   searchQuery: string;
+  filterType?: FundFilterType;
+  filterRestriction?: FundFilterRestriction;
+  sortBy?: FundSortBy;
 }) {
   const [funds, setFunds] = useState<Fund[]>([]);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Filter funds by name (case-insensitive). If there's no search text, show all funds.
   const router = useRouter();
 
-  const filteredFunds = searchQuery
-    ? funds.filter((fund) =>
-        (fund.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
-      )
-    : funds;
+  let filteredFunds = funds;
+  if (searchQuery) {
+    filteredFunds = filteredFunds.filter((f) =>
+      (f.name ?? "").toLowerCase().includes(searchQuery.toLowerCase())
+    );
+  }
+  if (filterType !== "all") {
+    filteredFunds = filteredFunds.filter((f) => f.type === filterType);
+  }
+  if (filterRestriction !== "all") {
+    filteredFunds = filteredFunds.filter((f) => f.restriction === filterRestriction);
+  }
+  filteredFunds = [...filteredFunds].sort((a, b) => {
+    if (sortBy === "name-asc") return a.name.localeCompare(b.name);
+    if (sortBy === "name-desc") return b.name.localeCompare(a.name);
+    if (sortBy === "amount-asc") return a.amount - b.amount;
+    if (sortBy === "amount-desc") return b.amount - a.amount;
+    return 0;
+  });
 
   useEffect(() => {
     fetchFunds();

--- a/frontend/src/components/molecules/SimpleTable.tsx
+++ b/frontend/src/components/molecules/SimpleTable.tsx
@@ -26,16 +26,17 @@ export type Column<T> = {
 
 // Define the props for the SimpleTable component
 type SimpleTableProps<T> = {
-  data: T[]; // Array of data objects to display
-  columns: Column<T>[]; // Configuration of table columns
-  pageSize: number; // Number of rows per page
+  data: T[];
+  columns: Column<T>[];
+  pageSize: number;
+  onRowClick?: (row: T) => void;
 };
 
-// Reusable table component with sorting and pagination
 export function SimpleTable<T extends Record<string, any>>({
   data,
   columns,
   pageSize,
+  onRowClick,
 }: SimpleTableProps<T>) {
   // State for current page, sorting column, and sort order
   const [currentPage, setCurrentPage] = useState(1);
@@ -150,7 +151,11 @@ export function SimpleTable<T extends Record<string, any>>({
           {/* Render table rows */}
           {paginatedData.length ? (
             paginatedData.map((row, rowIndex) => (
-              <TableRow key={rowIndex}>
+              <TableRow
+                key={rowIndex}
+                onClick={() => onRowClick?.(row)}
+                className={onRowClick ? "cursor-pointer hover:bg-gray-50" : ""}
+              >
                 {columns.map((column, colIndex) => {
                   const cellValue = row[column.accessor as keyof T];
                   return (

--- a/frontend/src/components/molecules/TransactionsTable.tsx
+++ b/frontend/src/components/molecules/TransactionsTable.tsx
@@ -43,19 +43,25 @@ interface TableData {
   documentLink?: string;
 }
 
+export type TransactionFilterType = "all" | "DONATION" | "WITHDRAWAL" | "INVESTMENT" | "EXPENSE";
+export type TransactionSortBy = "date-desc" | "date-asc" | "amount-desc" | "amount-asc" | "contributor-asc" | "contributor-desc";
+
 interface TransactionsTableProps {
   tableType: "transactions" | "contributions";
-  searchQuery?: string; // New prop to filter by organization name
-  fundId?: string; // Optional fundId to fetch transactions for a specific fund
-  fundName?: string; // Optional fund name to display when organization is missing
+  searchQuery?: string;
+  fundId?: string;
+  fundName?: string;
+  filterType?: TransactionFilterType;
+  sortBy?: TransactionSortBy;
 }
-
 
 const TransactionsTable: React.FC<TransactionsTableProps> = ({
   tableType,
-  searchQuery = "", // Default to empty string if not provided
+  searchQuery = "",
   fundId,
   fundName,
+  filterType = "all",
+  sortBy,
 }) => {
   const PAGE_SIZE = 5;
   const [transactions, setTransactions] = useState<TableData[]>([]);
@@ -135,38 +141,28 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
   // If the query is empty, return all transactions without filtering.
   const filteredTransactions = useMemo(() => {
     const q = (searchQuery ?? "").trim().toLowerCase();
-    if (!q) {
-      return transactions;
-    }
-    // Builds a single lowercase string containing all key fields of a table row,
-    // allowing flexible "search by anything" text matching across all attributes.
     const rowText = (t: TableData) =>
-      [
-        t.date,
-        t.contributor ?? "",
-        t.fund ?? "",
-        t.type ?? "",
-        t.units?.toString() ?? "",
-        (() => {
-          const sign = t.amount < 0 ? "-" : "+";
-          const amt = new Intl.NumberFormat("en-US", {
-            style: "currency",
-            currency: "USD",
-          }).format(Math.abs(t.amount));
-          return `${sign}${amt}`;
-        })(),
-        t.restriction ?? "",
-        t.documentLink ?? "",
-        t.id,
-      ]
-        .join("")
-        .toLowerCase();
+      [t.date, t.contributor ?? "", t.fund ?? "", t.type ?? "", t.units?.toString() ?? "", t.restriction ?? "", t.documentLink ?? "", t.id]
+        .join("").toLowerCase();
 
-    // Case-insensitive search for organization names (fund) containing the query string
-    return transactions.filter((transaction) =>
-      rowText(transaction).includes(q)
-    );
-  }, [transactions, searchQuery]);
+    let result = transactions
+      .filter((t) => filterType === "all" || t.type.toUpperCase() === filterType)
+      .filter((t) => !q || rowText(t).includes(q));
+
+    if (sortBy) {
+      result = [...result].sort((a, b) => {
+        if (sortBy === "date-desc") return new Date(b.date).getTime() - new Date(a.date).getTime();
+        if (sortBy === "date-asc") return new Date(a.date).getTime() - new Date(b.date).getTime();
+        if (sortBy === "amount-desc") return Math.abs(b.amount) - Math.abs(a.amount);
+        if (sortBy === "amount-asc") return Math.abs(a.amount) - Math.abs(b.amount);
+        if (sortBy === "contributor-asc") return (a.contributor ?? "").localeCompare(b.contributor ?? "");
+        if (sortBy === "contributor-desc") return (b.contributor ?? "").localeCompare(a.contributor ?? "");
+        return 0;
+      });
+    }
+
+    return result;
+  }, [transactions, searchQuery, filterType, sortBy]);
 
   const getColumns = (): Column<TableData>[] => {
     const baseColumns: Column<TableData>[] = [

--- a/frontend/src/components/templates/FundTemplate.tsx
+++ b/frontend/src/components/templates/FundTemplate.tsx
@@ -12,8 +12,9 @@ interface FundsTemplateProps {
   fundType?: string;
   summary: ReactNode;
   contributors: ReactNode;
-  activeTab: "summary" | "contributors";
-  onTabChange: (tab: "summary" | "contributors") => void;
+  settings: ReactNode;
+  activeTab: "summary" | "contributors" | "settings";
+  onTabChange: (tab: "summary" | "contributors" | "settings") => void;
 }
 
 const FundTemplate = ({
@@ -22,6 +23,7 @@ const FundTemplate = ({
   fundType,
   summary,
   contributors,
+  settings,
   activeTab,
   onTabChange,
 }: FundsTemplateProps) => {
@@ -72,9 +74,9 @@ const FundTemplate = ({
           </div>
         )}
 
-        {/* Tabs — only Summary and Contributors */}
+        {/* Tabs */}
         <div className="mb-6 flex space-x-8 border-b">
-          {(["summary", "contributors"] as const).map((tab) => (
+          {(["summary", "contributors", "settings"] as const).map((tab) => (
             <button
               key={tab}
               className={`pb-3 text-base capitalize transition-colors ${
@@ -93,6 +95,7 @@ const FundTemplate = ({
         <div>
           {activeTab === "summary" && summary}
           {activeTab === "contributors" && contributors}
+          {activeTab === "settings" && settings}
         </div>
       </div>
 

--- a/frontend/src/components/templates/FundTemplate.tsx
+++ b/frontend/src/components/templates/FundTemplate.tsx
@@ -1,5 +1,5 @@
 "use client";
-import React, { ReactNode, useState } from "react";
+import { ReactNode, useState } from "react";
 import Sidebar from "@/components/molecules/Sidebar";
 import { IconButton, useMediaQuery } from "@mui/material";
 import MenuIcon from "@mui/icons-material/Menu";
@@ -9,18 +9,18 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 interface FundsTemplateProps {
   fundName: string;
   fundDescription: string;
+  fundType?: string;
   summary: ReactNode;
-  transactions: ReactNode;
   contributors: ReactNode;
-  activeTab: "summary" | "transactions" | "contributors";
-  onTabChange: (tab: "summary" | "transactions" | "contributors") => void;
+  activeTab: "summary" | "contributors";
+  onTabChange: (tab: "summary" | "contributors") => void;
 }
 
 const FundTemplate = ({
   fundName,
   fundDescription,
+  fundType,
   summary,
-  transactions,
   contributors,
   activeTab,
   onTabChange,
@@ -29,16 +29,12 @@ const FundTemplate = ({
   const isMobile = useMediaQuery("(max-width: 768px)");
   const router = useRouter();
 
-  const handleToggleSidebar = () => {
-    setCollapsed(!collapsed);
-  };
-
   return (
     <div className="dark:bg-gray-900 dark:text-gray-300 flex min-h-screen">
       <Sidebar
         collapsed={collapsed}
-        handleToggleSidebar={handleToggleSidebar}
-        user={null} // no user context here; sidebar will show "Profile"
+        handleToggleSidebar={() => setCollapsed(!collapsed)}
+        user={null}
       />
 
       <div
@@ -52,36 +48,43 @@ const FundTemplate = ({
       >
         {/* Back button */}
         <button
-          className="text-blue-600 mb-4 text-sm"
+          className="text-gray-500 mb-6 flex items-center gap-1 text-sm hover:text-gray-700"
           onClick={() => router.back()}
         >
-          <ArrowBackIcon
-            className="relative top-[-1px] mr-1"
-            fontSize="small"
-          />
+          <ArrowBackIcon fontSize="small" />
           Back to All Funds
         </button>
 
-        {/* Fund title and description */}
-        <h1 className="mb-1 text-3xl font-semibold">{fundName}</h1>
-        <p className="text-gray-600 mb-6 max-w-3xl">{fundDescription}
+        {/* Fund title */}
+        <h1 className="mb-2 text-4xl font-bold">{fundName}</h1>
+
+        {/* Fund description */}
+        <p className="text-gray-600 mb-4 max-w-3xl text-sm leading-relaxed">
+          {fundDescription}
         </p>
 
-        {/* Tabs */}
-        <div className="mb-6 flex space-x-6 border-b">
-          {["summary", "transactions", "contributors"].map((tab) => (
+        {/* Badges */}
+        {fundType && (
+          <div className="mb-6 flex gap-2">
+            <span className="border-gray-300 text-gray-600 rounded border px-3 py-1 text-xs">
+              {fundType}
+            </span>
+          </div>
+        )}
+
+        {/* Tabs — only Summary and Contributors */}
+        <div className="mb-6 flex space-x-8 border-b">
+          {(["summary", "contributors"] as const).map((tab) => (
             <button
               key={tab}
-              className={`pb-2 capitalize ${
-              activeTab === tab
-                  ? "border-blue-600 border-b-2 font-semibold"
-                  : "text-gray-500"
+              className={`pb-3 text-base capitalize transition-colors ${
+                activeTab === tab
+                  ? "border-b-2 border-black font-semibold text-black"
+                  : "text-gray-400 hover:text-gray-600"
               }`}
-              onClick={() =>
-                onTabChange(tab as "summary" | "transactions" | "contributors")
-              }
+              onClick={() => onTabChange(tab)}
             >
-              {tab}
+              {tab.charAt(0).toUpperCase() + tab.slice(1)}
             </button>
           ))}
         </div>
@@ -89,20 +92,14 @@ const FundTemplate = ({
         {/* Content */}
         <div>
           {activeTab === "summary" && summary}
-          {activeTab === "transactions" && transactions}
           {activeTab === "contributors" && contributors}
         </div>
       </div>
 
       {isMobile && (
         <IconButton
-          onClick={handleToggleSidebar}
-          style={{
-            position: "fixed",
-            top: 16,
-            left: 16,
-            zIndex: 1000,
-          }}
+          onClick={() => setCollapsed(!collapsed)}
+          style={{ position: "fixed", top: 16, left: 16, zIndex: 1000 }}
         >
           <MenuIcon />
         </IconButton>


### PR DESCRIPTION
# PR: Frontend Redesign & Internal Dashboard Improvements

## Dashboard

- Replaced static org-name header with a live **Dashboard** title and redesigned layout
- Added **stat cards** showing range-filtered return rate, earnings, and contributions
- Added **"Your Total Contribution"** section with a `ContributionsGraph` whose range is lifted to the page (Last Month / Last Year / All)
- Added **"Your Activity Level"** section with a `BarGraph` whose range is lifted to the page so the contribution count and export both reflect the active filter
- Added **"Your Contributors"** section showing top contributors filtered by selected time range (Last Year / Last Month / Today)
- Replaced all legacy SVG export buttons with a unified `ExportButton` component that downloads a CSV filtered to the section's active range
- Removed four action buttons (Add Contributor, Add Transaction, etc.) from the Contributors section; replaced with a single Export button
- Removed the dashboard search bar
- Added `downloadCSV` utility that generates and triggers a browser download without any server round-trip

## Activity Page

- Bolded the **Activity** page title to match Dashboard/Contributors/Funds
- Replaced MUI `AddIcon` + `DownloadIcon` buttons with:
  - Filled blue **Add Transaction** button (white text, `Plus` icon)
  - Outlined **Export** button matching dashboard style (`ArrowUpRight` icon)
- Added **Filter** dropdown (All / Donation / Investment / Withdrawal / Expense) using `FilterAltIcon` + `Button`, rendered via portal
- Added **Sort** dropdown (Date newest/oldest, Amount high/low, Contributor A–Z / Z–A) using `SwapVertIcon` + `Button`, rendered via portal
- Stretched search bar to fill available space (no dead gap before Filter button)
- All three controls (filter, sort, search) wired to `TransactionsTable` as props

## Funds Page

- Added `onMouseDown stopPropagation` to filter and sort portal divs so radio buttons are selectable

## Fund Detail Page (`/funds/[fundId]`)

- Replaced the "transactions" tab with a **Settings** tab
- Added full **Fund Settings** form: name, description, type, restriction toggle, purpose (shown only when restricted), and unit rate — with Save/Discard actions and success/error feedback
- Added **Contributors tab** showing each contributor's name and their total contributions to that fund
- Removed static `Account Balance` (`fundData.amount`) display; the live `ContributionsGraph` is the sole balance display
- Removed **Add Transaction** and **Add Contributor** buttons from the Summary tab
- Removed the search bar from the Contributors tab
- Fixed Contributors tab column header from "Date" to "Name"
- Added 1-year return % and 1-year earnings stats below the graph (computed from live transaction data)

## ContributionsGraph Component

- Graph line now goes **down** on withdrawals and expenses (cumulative -= amount)
- Renamed label from "Overall Contributions" to **"Account Balance"**
- The displayed dollar amount now shows the **delta for the selected range** (last value in range minus value just before the range started), not the all-time cumulative total — so Last Month / Last Year filters update the number correctly

## BarGraph Component

- Added `range` / `onRangeChange` props (controlled component pattern) so the dashboard can lift range state and use it for filtered exports
- Falls back to internal state when props are not provided (backwards-compatible)

## TransactionsTable Component

- Exported `TransactionFilterType` and `TransactionSortBy` types
- Added `filterType` and `sortBy` props; `filteredTransactions` useMemo applies both

## ContributorsTable Component

- Exported `ContributorFilterBy` type and added `filterBy` prop
- Added `transactionTypes` field to `TableData` to support type-based filtering

## Contributors Page

- Unified search/sort UI to match Activity and Funds pages (Button + MUI icons, portal dropdown with `onMouseDown stopPropagation`)
- Removed filter dropdown (sort only)

## Contributor Detail Page (`/contributors/[id]`) — New Page

- New page showing a contributor's full profile: name, linked funds, and all transactions
- Includes a cumulative contributions line chart (using Recharts)
- Includes a transactions table with date, fund, and amount columns
- Export button for contributor transaction history

## Backend / Seed

- Added 25 historical transactions (`tx-041` through `tx-065`) spanning 2–3 years across all four funds, enabling meaningful Last Month / Last Year / All filter comparisons in the graph
- Seed uses `upsert` with fixed IDs so it is safe to re-run without creating duplicates
